### PR TITLE
rename step in readme pipeline

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ from sklearn.pipeline import Pipeline
 
 mod = Pipeline([
     ("scale", StandardScaler()),
-    ("pca", RandomAdder()),
+    ("random_noise", RandomAdder()),
     ("model", LogisticRegression(solver='lbfgs'))
 ])
 


### PR DESCRIPTION
Step containing `RandomAdder` was still named `pca`