### PR TITLE
Update the badges

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
-![](https://travis-ci.com/koaning/scikit-lego.svg?branch=master) [![Build status](https://ci.appveyor.com/api/projects/status/66r9jjs844v8c5qh?svg=true)](https://ci.appveyor.com/project/koaning/scikit-lego) [![Documentation Status](https://readthedocs.org/projects/scikit-lego/badge/?version=latest)](https://scikit-lego.readthedocs.io/en/latest/?badge=latest)
+[![Build Status](https://travis-ci.org/koaning/scikit-lego.svg?branch=master)](https://travis-ci.org/koaning/scikit-lego)
+(https://ci.appveyor.com/api/projects/status/66r9jjs844v8c5qh?svg=true)](https://ci.appveyor.com/project/koaning/scikit-lego)
+[![Documentation Status](https://readthedocs.org/projects/scikit-lego/badge/?version=latest)](https://scikit-lego.readthedocs.io/en/latest/?badge=latest)
 
 
 


### PR DESCRIPTION
Make the links clickable as well.

I couldn't update the AppVeyor one since it is on the settings page on which only you have access: You can see a badge image URL and sample markup on the Badges tab of project settings. Badge URLs for both private and public projects contain a security token.

