### PR TITLE
Use pyenv to set Python 3 as the default version in Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,3 @@
 tasks:
-  - init: pip3 install -e ".[dev]"
-    command: python3 setup.py develop
+  - init: pyenv local 3.7.2 && pip install -e ".[dev]"
+    command: python setup.py develop


### PR DESCRIPTION
This will create a `.python-version` file in your workspace, causing all Python commands to use Python 3 (i.e. `pip`, `python`, etc.)

Alternatively, you could also just commit this `.python-version` file instead of running `pyenv local 3.7.2` on start-up, but as it is currently ignored by your `.gitignore`, I'm proposing the `.gitpod.yml` approach here.

Please let me know what you think. 🙂 