### PR TITLE
Bugfix/p percent divide by zero

### DIFF
--- a/sklego/metrics.py
+++ b/sklego/metrics.py
@@ -1,6 +1,7 @@
 import numpy as np
 import warnings
 
+
 def correlation_score(column):
     """
     The correlation score can score how well the estimator predictions
@@ -54,11 +55,11 @@ def p_percent_score(column, positive_target=1):
         # If we never predict a positive target for one of the subgroups, the model is by definition not
         # fair so we return 0
         if p_y1_z1 == 0:
-            warnings.warn(f"No samples with y_hat == {positive_target} for {column} == 1, returning 0")
+            warnings.warn(f"No samples with y_hat == {positive_target} for {column} == 1, returning 0", RuntimeWarning)
             return 0
 
         if p_y1_z0 == 0:
-            warnings.warn(f"No samples with y_hat == {positive_target} for {column} == 0, returning 0")
+            warnings.warn(f"No samples with y_hat == {positive_target} for {column} == 0, returning 0", RuntimeWarning)
             return 0
 
         p_percent = np.minimum(p_y1_z1 / p_y1_z0, p_y1_z0 / p_y1_z1)

--- a/sklego/metrics.py
+++ b/sklego/metrics.py
@@ -1,5 +1,5 @@
 import numpy as np
-
+import warnings
 
 def correlation_score(column):
     """
@@ -50,6 +50,16 @@ def p_percent_score(column, positive_target=1):
         y_given_z0 = y_hat[sensitive_col == 0]
         p_y1_z1 = np.mean(y_given_z1 == positive_target)
         p_y1_z0 = np.mean(y_given_z0 == positive_target)
+
+        # If we never predict a positive target for one of the subgroups, the model is by definition not
+        # fair so we return 0
+        if p_y1_z1 == 0:
+            warnings.warn(f"No samples with y_hat == {positive_target} for {column} == 1, returning 0")
+            return 0
+
+        if p_y1_z0 == 0:
+            warnings.warn(f"No samples with y_hat == {positive_target} for {column} == 0, returning 0")
+            return 0
 
         p_percent = np.minimum(p_y1_z1 / p_y1_z0, p_y1_z0 / p_y1_z1)
         return p_percent if not np.isnan(p_percent) else 1

--- a/tests/test_metrics/test_neg_p_percent.py
+++ b/tests/test_metrics/test_neg_p_percent.py
@@ -1,4 +1,6 @@
 import pytest
+import warnings
+
 from sklearn.linear_model import LogisticRegression
 from sklearn.pipeline import make_pipeline
 
@@ -37,3 +39,17 @@ def test_p_percent_numpy(sensitive_classification_dataset):
     X = X.values
     mod = LogisticRegression().fit(X, y)
     assert p_percent_score(1)(mod, X) == 0
+
+
+def test_warning_is_logged(sensitive_classification_dataset):
+    X, y = sensitive_classification_dataset
+    mod_fair = make_pipeline(
+        ColumnSelector('x1'),
+        LogisticRegression(),
+    ).fit(X, y)
+    with warnings.catch_warnings(record=True) as w:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+        # Trigger a warning.
+        p_percent_score("x2", positive_target=2)(mod_fair, X)
+        assert issubclass(w[-1].category, RuntimeWarning)

--- a/tests/test_metrics/test_neg_p_percent.py
+++ b/tests/test_metrics/test_neg_p_percent.py
@@ -29,7 +29,7 @@ def test_p_percent_pandas_multiclass(sensitive_multiclass_classification_dataset
         LogisticRegression(),
     ).fit(X, y)
     assert p_percent_score("x2")(mod_fair, X) == pytest.approx(0.9333333)
-    assert p_percent_score("x2", positive_target=2)(mod_fair, X) == 1
+    assert p_percent_score("x2", positive_target=2)(mod_fair, X) == 0
 
 
 def test_p_percent_numpy(sensitive_classification_dataset):


### PR DESCRIPTION
I discussed https://github.com/koaning/scikit-lego/issues/163 with @MBrouns and we agreed that a wall of red warnings does not look nice but it should be something that the users should control themselves with for example `warnings.filterwarnings('once')`.

However, if a division by zero occurs, the p_percent_score should be 0. If you never predict a positive target for one of the subgroups the model is not fair by definition. In this pull request, I implemented functionality to warn the user about this.