### PR TITLE
h1 turned into h2 -> fixed

### DIFF
--- a/doc/debug_pipeline.ipynb
+++ b/doc/debug_pipeline.ipynb
@@ -261,7 +261,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Feature union\n",
+    "## Feature union\n",
     "\n",
     "Feature union also works with the debug pipeline."
    ]


### PR DESCRIPTION
There was one h1 tag for something that was h2 that messed up the title screen of sphinx. Fixed it now. 