### PR TITLE
implement get_feature_names on pandas transformers

### DIFF
--- a/tests/test_preprocessing/test_columndropper.py
+++ b/tests/test_preprocessing/test_columndropper.py
@@ -55,3 +55,12 @@ def test_drop_one_in_pipeline(df):
         "d": ["b", "a", "a", "b", "a", "b"]})
 
     assert_frame_equal(result_df, expected_df)
+
+
+def test_get_feature_names():
+    df = pd.DataFrame({
+        'a': [4, 5, 6],
+        'b': ['4', '5', '6']
+    })
+    transformer = ColumnDropper('a').fit(df)
+    assert transformer.get_feature_names() == ['b']

--- a/tests/test_preprocessing/test_pandastypeselector.py
+++ b/tests/test_preprocessing/test_pandastypeselector.py
@@ -61,6 +61,18 @@ def test_value_error_differrent_dtyes():
         transformer.transform(transform_df)
 
 
+def test_get_feature_names():
+    df = pd.DataFrame({
+        'a': [4, 5, 6],
+        'b': ['4', '5', '6']
+    })
+    transformer_number = PandasTypeSelector(include='number').fit(df)
+    assert transformer_number.get_feature_names() == ['a']
+
+    transformer_number = PandasTypeSelector(include='object').fit(df)
+    assert transformer_number.get_feature_names() == ['b']
+
+
 def test_value_error_empty(random_xy_dataset_regr):
     transformer = PandasTypeSelector(exclude=['number'])
     X, y = random_xy_dataset_regr


### PR DESCRIPTION
implementing `get_feature_names` allows for easier interoperability with libraries such as ELI5. For now, I implemented it only on the transformers which work on Pandas objects although I think it should work on the others as well