### PR TITLE
Remove redundant if condition

### DIFF
--- a/sklego/dummy.py
+++ b/sklego/dummy.py
@@ -13,7 +13,6 @@ class RandomRegressor(BaseEstimator, RegressorMixin):
     :param str strategy: how we want to select random values, can be "uniform" or "normal"
     :param int seed: the seed value, default: 42
     """
-
     def __init__(self, strategy="uniform", random_state=None):
         self.allowed_strategies = ("uniform", "normal")
         self.random_state = random_state

--- a/sklego/dummy.py
+++ b/sklego/dummy.py
@@ -13,6 +13,7 @@ class RandomRegressor(BaseEstimator, RegressorMixin):
     :param str strategy: how we want to select random values, can be "uniform" or "normal"
     :param int seed: the seed value, default: 42
     """
+
     def __init__(self, strategy="uniform", random_state=None):
         self.allowed_strategies = ("uniform", "normal")
         self.random_state = random_state
@@ -51,8 +52,6 @@ class RandomRegressor(BaseEstimator, RegressorMixin):
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         if X.shape[1] != self.dim_:
             raise ValueError(f'Unexpected input dimension {X.shape[1]}, expected {self.dim_}')
-        if self.strategy not in self.allowed_strategies:
-            raise ValueError(f"strategy {self.strategy} is not in {self.allowed_strategies}")
 
         if self.strategy == 'normal':
             return rs.normal(self.mu_, self.sigma_, X.shape[0])

--- a/sklego/naive_bayes.py
+++ b/sklego/naive_bayes.py
@@ -63,6 +63,7 @@ class GaussianMixtureNB(BaseEstimator, ClassifierMixin):
         return self.classes_[self.predict_proba(X).argmax(axis=1)]
 
     def predict_proba(self, X: np.array):
+        check_is_fitted(self, ['gmms_', 'classes_'])
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         if self.num_fit_cols_ != X.shape[1]:
             raise ValueError(f"number of columns {X.shape[1]} does not match fit size {self.num_fit_cols_}")
@@ -143,11 +144,12 @@ class BayesianGaussianMixtureNB(BaseEstimator, ClassifierMixin):
         return self
 
     def predict(self, X):
-        check_is_fitted(self, ['gmms_', 'classes_'])
+        check_is_fitted(self, ['gmms_', 'classes_', 'num_fit_cols_'])
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         return self.classes_[self.predict_proba(X).argmax(axis=1)]
 
     def predict_proba(self, X: np.array):
+        check_is_fitted(self, ['gmms_', 'classes_', 'num_fit_cols_'])
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         if self.num_fit_cols_ != X.shape[1]:
             raise ValueError(f"number of columns {X.shape[1]} does not match fit size {self.num_fit_cols_}")


### PR DESCRIPTION
Sorry, I am not creating an issue first because it's just oneliner.

In predict() of RandomRegressor, the following if always evaluates to False hence is redundant,

    if self.strategy not in self.allowed_strategies:
            raise ValueError(f"strategy {self.strategy} is not in {self.allowed_strategies}")

This is because it has been already checked in fit method and their is no way to predict without fitting.