### PR TITLE
Adding Verbosity to GMM Classifiers

### DIFF
--- a/sklego/mixture.py
+++ b/sklego/mixture.py
@@ -225,6 +225,8 @@ class GMMOutlierDetector(OutlierMixin, BaseEstimator):
         precisions_init=None,
         random_state=None,
         warm_start=False,
+        verbose=0,
+        verbose_interval=10
     ):
         self.threshold = threshold
         self.method = method
@@ -242,6 +244,8 @@ class GMMOutlierDetector(OutlierMixin, BaseEstimator):
         self.precisions_init = precisions_init
         self.random_state = random_state
         self.warm_start = warm_start
+        self.verbose = verbose
+        self.verbose_interval = verbose_interval
 
     def fit(self, X: np.array, y=None) -> "GMMOutlierDetector":
         """
@@ -285,6 +289,8 @@ class GMMOutlierDetector(OutlierMixin, BaseEstimator):
             precisions_init=self.precisions_init,
             random_state=self.random_state,
             warm_start=self.warm_start,
+            verbose=self.verbose,
+            verbose_interval=self.verbose_interval
         )
         self.gmm_.fit(X)
         score_samples = self.gmm_.score_samples(X)

--- a/sklego/mixture.py
+++ b/sklego/mixture.py
@@ -25,7 +25,7 @@ class GMMClassifier(BaseEstimator, ClassifierMixin):
         random_state=None,
         warm_start=False,
         verbose=0,
-        verbose_interval=10
+        verbose_interval=10,
     ):
         """
         The GMMClassifier trains a Gaussian Mixture Model for each class in y on a dataset X. Once
@@ -77,7 +77,7 @@ class GMMClassifier(BaseEstimator, ClassifierMixin):
                 random_state=self.random_state,
                 warm_start=self.warm_start,
                 verbose=self.verbose,
-                verbose_interval=self.verbose_interval
+                verbose_interval=self.verbose_interval,
             )
             self.gmms_[c] = mixture.fit(subset_x, subset_y)
         return self
@@ -226,7 +226,7 @@ class GMMOutlierDetector(OutlierMixin, BaseEstimator):
         random_state=None,
         warm_start=False,
         verbose=0,
-        verbose_interval=10
+        verbose_interval=10,
     ):
         self.threshold = threshold
         self.method = method
@@ -290,7 +290,7 @@ class GMMOutlierDetector(OutlierMixin, BaseEstimator):
             random_state=self.random_state,
             warm_start=self.warm_start,
             verbose=self.verbose,
-            verbose_interval=self.verbose_interval
+            verbose_interval=self.verbose_interval,
         )
         self.gmm_.fit(X)
         score_samples = self.gmm_.score_samples(X)

--- a/sklego/mixture.py
+++ b/sklego/mixture.py
@@ -24,6 +24,8 @@ class GMMClassifier(BaseEstimator, ClassifierMixin):
         precisions_init=None,
         random_state=None,
         warm_start=False,
+        verbose=0,
+        verbose_interval=10
     ):
         """
         The GMMClassifier trains a Gaussian Mixture Model for each class in y on a dataset X. Once
@@ -42,6 +44,8 @@ class GMMClassifier(BaseEstimator, ClassifierMixin):
         self.precisions_init = precisions_init
         self.random_state = random_state
         self.warm_start = warm_start
+        self.verbose = verbose,
+        self.verbose_interval = verbose_interval
 
     def fit(self, X: np.array, y: np.array) -> "GMMClassifier":
         """
@@ -72,6 +76,8 @@ class GMMClassifier(BaseEstimator, ClassifierMixin):
                 precisions_init=self.precisions_init,
                 random_state=self.random_state,
                 warm_start=self.warm_start,
+                verbose=self.verbose,
+                verbose_interval=self.verbose_interval
             )
             self.gmms_[c] = mixture.fit(subset_x, subset_y)
         return self

--- a/sklego/mixture.py
+++ b/sklego/mixture.py
@@ -44,7 +44,7 @@ class GMMClassifier(BaseEstimator, ClassifierMixin):
         self.precisions_init = precisions_init
         self.random_state = random_state
         self.warm_start = warm_start
-        self.verbose = verbose,
+        self.verbose = verbose
         self.verbose_interval = verbose_interval
 
     def fit(self, X: np.array, y: np.array) -> "GMMClassifier":


### PR DESCRIPTION
The bayesian classifiers have verbosity the mle version does not.

Perhaps also adding `**gmm_kwargs` would permanently solve this problem.