### PR TITLE
h2 tag

### DIFF
--- a/doc/fairness.ipynb
+++ b/doc/fairness.ipynb
@@ -836,7 +836,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Sources\n",
+    "## Sources\n",
     "\n",
     "<ol>\n",
     "    <li id=\"fn1\">M. Zafar et al. (2017), Fairness Constraints: Mechanisms for Fair Classification</li>\n",
@@ -862,7 +862,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
it's a good thing we've added sources, but it should be an h2 tag instead of h1. it now renders like this; 

![image](https://user-images.githubusercontent.com/1019791/74100413-ec1b1c80-4b2e-11ea-9730-abc9f297a5ea.png)
