### PR TITLE
add return_type argument to PatsyTransformer

### DIFF
--- a/sklego/preprocessing/patsytransformer.py
+++ b/sklego/preprocessing/patsytransformer.py
@@ -9,18 +9,21 @@ class PatsyTransformer(TransformerMixin, BaseEstimator):
     The patsy transformer offers a method to select the right columns
     from a dataframe as well as a DSL for transformations. It is inspired
     from R formulas.
-
     This is can be useful as a first step in the pipeline.
-
     :param formula: a patsy-compatible formula
+    :return_type: Either "matrix" or "dataframe", passed on to patsy
     """
 
-    def __init__(self, formula):
+    def __init__(self, formula, return_type="matrix"):
         self.formula = formula
+        self.return_type = return_type
 
     def fit(self, X, y=None):
         """Fits the estimator"""
-        X_ = dmatrix(self.formula, X)
+        X_ = dmatrix(self.formula, X, NA_action="raise", return_type=self.return_type)
+
+        # check the number of observations hasn't changed. This ought not to
+        # be necessary given NA_action='raise' above but just to be safe
         assert np.array(X_).shape[0] == np.array(X).shape[0]
         self.design_info_ = X_.design_info
         return self
@@ -29,10 +32,14 @@ class PatsyTransformer(TransformerMixin, BaseEstimator):
         """
         Applies the formula to the matrix/dataframe X.
 
-        Returns an design array that can be used in sklearn pipelines.
+        Returns
+        - A patsy.DesignMatrix, if return_type="matrix" (the default)
+        - A pandas.DataFrame, if return_type="dataframe"
         """
         check_is_fitted(self, "design_info_")
         try:
-            return build_design_matrices([self.design_info_], X)[0]
+            return build_design_matrices(
+                [self.design_info_], X, return_type=self.return_type
+            )[0]
         except PatsyError as e:
             raise RuntimeError from e

--- a/tests/test_preprocessing/test_patsy_transformer.py
+++ b/tests/test_preprocessing/test_patsy_transformer.py
@@ -22,6 +22,21 @@ def df():
     )
 
 
+def test_return_type_dmatrix(df):
+    X, y = df[["a", "b", "c", "d"]], df[["e"]]
+    tf = PatsyTransformer("a + b - 1", return_type="matrix")
+    # test for DesignMatrix this way as per https://patsy.readthedocs.io/en/latest/API-reference.html#patsy.DesignMatrix
+    df_fit_transformed = tf.fit(X, y).transform(X)
+    assert hasattr(df_fit_transformed, "design_info")
+
+
+def test_return_type_dataframe(df):
+    X, y = df[["a", "b", "c", "d"]], df[["e"]]
+    tf = PatsyTransformer("a + b - 1", return_type="dataframe")
+    df_fit_transformed = tf.fit(X, y).transform(X)
+    assert isinstance(df_fit_transformed, pd.DataFrame)
+
+
 def test_basic_usage(df):
     X, y = df[["a", "b", "c", "d"]], df[["e"]]
     tf = PatsyTransformer("a + b")


### PR DESCRIPTION
Passing `return_type='dataframe'` makes PatsyTransformer return a pandas DataFrame, which has the advantage of being immediately digestible by other Transformers that rely on the presence of column names. 