### PR TITLE
Include __all__ statement s.t. preprocessing classes are documented

### DIFF
--- a/sklego/preprocessing/__init__.py
+++ b/sklego/preprocessing/__init__.py
@@ -1,3 +1,16 @@
+__all__ = [
+    "IntervalEncoder",
+    "RandomAdder",
+    "Patsytransformer",
+    "ColumnSelector",
+    "PandasTypeSelector",
+    "ColumnDropper",
+    "InformationFilter",
+    "OrthogonalTransformer",
+    "RepeatingBasisFunction",
+    "ColumnCapper",
+]
+
 from .intervalencoder import IntervalEncoder
 from .randomadder import RandomAdder
 from .patsytransformer import PatsyTransformer


### PR DESCRIPTION
By including an `__all__` statement in the `__init__.py` we ensure that sphinx picks up the right components from the submodule. A side effect is that you can now use `from preprocessing import *`

**Downside:** Needs maintaining whenever new functionality is added to the submodule: this is already kind of the case because of the include statements in the init.