### PR TITLE
Small Test Speedup

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -36,4 +36,4 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest
-        pytest -n auto tests
+        pytest -n 2 tests

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[dev]"
+        pip install -e ".[test]"
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -36,4 +36,4 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest
-        pytest
+        pytest -n auto tests

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -36,4 +36,4 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest
-        pytest -n auto tests
+        pytest -n 2 tests

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -36,4 +36,5 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest
-        pytest
+        pytest -n auto tests
+        # 75.38s

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -37,4 +37,3 @@ jobs:
       run: |
         pip install pytest
         pytest -n auto tests
-        # 75.38s

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[dev]"
+        pip install -e ".[test]"
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ test_packages = [
     "flake8>=3.6.0",
     "nbval>=0.9.1",
     "pytest>=4.0.2",
+    "pytest-xdist>=1.32.0",
     "black>=19.3b0",
     "pytest-cov>=2.6.1",
     "pytest-mock>=1.6.3",


### PR DESCRIPTION
I've added the `pytest-xdist` package which allows unit tests to be run in parallel. 

A github action worker should have two cores so we'll see what the exact effect of it is. Locally it's made a *huge* difference. From  223.29s to 75.38s. 