### PR TITLE
Another small mistake in linear model docs, missing round brackets in…

### DIFF
--- a/doc/linear-models.ipynb
+++ b/doc/linear-models.ipynb
@@ -131,7 +131,7 @@
    "source": [
     "\\begin{equation} \\label{eq1}\n",
     "\\begin{split}\n",
-    "\\text{min} & \\sum_i (y_i - w_1 y_{1,i} + w_2 y_{2,i} + w_3 y_{3,i})^2 \\\\\n",
+    "\\text{min} & \\sum_i (y_i - (w_1 y_{1,i} + w_2 y_{2,i} + w_3 y_{3,i}))^2 \\\\\n",
     "\\text{subject to} & \\\\\n",
     "& \\text{ } w_1 + w_2 + w_3 = 1 \\\\ \n",
     "& \\text{ } w_1 \\geq 0, w_2 \\geq 0, w_3 \\geq 0\n",


### PR DESCRIPTION
… loss function

Missing yi - wyi1 + wyi2 + wyi3

should be

yi - (wyi1 + wyi2 + wyi3)  or yi - wyi1 - wyi2 - wyi3 

---

Missed it as well the first time reading through it, I wish I added this change already to the previous pull request. 

My apologies. 