### PR TITLE
[DOCS] Fix misaligned heading at Confusion Balancer

### DIFF
--- a/doc/meta.ipynb
+++ b/doc/meta.ipynb
@@ -450,7 +450,7 @@
     "The decay parameter has a lot of influence on the effect of the model but one\n",
     "can clearly see that we shift focus to the more recent data.\n",
     "\n",
-    "# Confusion Balancer \n",
+    "## Confusion Balancer \n",
     "\n",
     "**Disclaimer**: This is an experimental feature. \n",
     "\n",


### PR DESCRIPTION
Prevents "Confusion Balancer" from appearing in the wrong level
of the documentation outline. Fixes #293.