### PR TITLE
Update pandas_utils.py

### DIFF
--- a/sklego/pandas_utils.py
+++ b/sklego/pandas_utils.py
@@ -27,7 +27,7 @@ def log_step(
     names=False,
     dtypes=False,
     print_fn=print,
-    print_args=True
+    display_args=True
 ):
     """
     Decorates a function that transforms a pandas dataframe to add automated logging statements
@@ -62,7 +62,7 @@ def log_step(
             names=names,
             dtypes=dtypes,
             print_fn=print_fn,
-            print_args=print_args
+            display_args=display_args
         )
 
     names = False if dtypes else names
@@ -85,7 +85,7 @@ def log_step(
 
         combined = " ".join([s for s in optional_strings if s])
 
-        if print_args:
+        if display_args:
 
             func_args = inspect.signature(func).bind(*args, **kwargs).arguments
             func_args_str = "".join(

--- a/sklego/pandas_utils.py
+++ b/sklego/pandas_utils.py
@@ -27,6 +27,7 @@ def log_step(
     names=False,
     dtypes=False,
     print_fn=print,
+    print_args=True
 ):
     """
     Decorates a function that transforms a pandas dataframe to add automated logging statements
@@ -38,6 +39,7 @@ def log_step(
     :param names: bool, log the names of the columns of the result, defaults to False
     :param dtypes: bool, log the dtypes of the results, defaults to False
     :param print_fn: callable, print function (e.g. print or logger.info), defaults to print
+    :param print_args: bool, whether or not to print the arguments given to the function.
     :returns: the result of the function
 
     :Example:
@@ -60,6 +62,7 @@ def log_step(
             names=names,
             dtypes=dtypes,
             print_fn=print_fn,
+            print_args=print_args
         )
 
     names = False if dtypes else names
@@ -86,8 +89,10 @@ def log_step(
         func_args_str = "".join(
             ", {} = {!r}".format(*item) for item in list(func_args.items())[1:]
         )
-        print_fn(f"[{func.__name__}(df{func_args_str})] " + combined,)
-
+        if print_args:
+            print_fn(f"[{func.__name__}(df{func_args_str})] " + combined,)
+        else:
+            print_fn(f"[{func.__name__}()")
         return result
 
     return wrapper

--- a/sklego/pandas_utils.py
+++ b/sklego/pandas_utils.py
@@ -92,7 +92,7 @@ def log_step(
         if print_args:
             print_fn(f"[{func.__name__}(df{func_args_str})] " + combined,)
         else:
-            print_fn(f"[{func.__name__}()")
+            print_fn(f"[{func.__name__}]" + combined,)
         return result
 
     return wrapper

--- a/sklego/pandas_utils.py
+++ b/sklego/pandas_utils.py
@@ -85,11 +85,12 @@ def log_step(
 
         combined = " ".join([s for s in optional_strings if s])
 
-        func_args = inspect.signature(func).bind(*args, **kwargs).arguments
-        func_args_str = "".join(
-            ", {} = {!r}".format(*item) for item in list(func_args.items())[1:]
-        )
         if print_args:
+
+            func_args = inspect.signature(func).bind(*args, **kwargs).arguments
+            func_args_str = "".join(
+                ", {} = {!r}".format(*item) for item in list(func_args.items())[1:]
+            )
             print_fn(f"[{func.__name__}(df{func_args_str})] " + combined,)
         else:
             print_fn(f"[{func.__name__}]" + combined,)

--- a/tests/test_pandas_utils/test_pandas_utils.py
+++ b/tests/test_pandas_utils/test_pandas_utils.py
@@ -97,10 +97,9 @@ def test_log_step_display_args(capsys, test_df):
     captured = capsys.readouterr()
     print_statements = captured.out.split("\n")
 
-    assert print_statements[0].startswith("[do_nothing(df)]")
-    raise Exception(print_statements[1])
+    assert print_statements[0].startswith("[do_nothing]") 
     assert "kwargs = {'a': '1'}" not in print_statements[1]
-    assert print_statements[2].startswith("[do_something(df)]")
+    assert print_statements[2].startswith("[do_something]")
 
 
 def test_log_step_logger(caplog, test_df):

--- a/tests/test_pandas_utils/test_pandas_utils.py
+++ b/tests/test_pandas_utils/test_pandas_utils.py
@@ -88,7 +88,7 @@ def test_log_step_display_args(capsys, test_df):
     def do_something(df):
         return df.drop(0)
 
-    @log_step
+    @log_step(display_args=False)
     def do_nothing(df, *args, **kwargs):
         return df
 

--- a/tests/test_pandas_utils/test_pandas_utils.py
+++ b/tests/test_pandas_utils/test_pandas_utils.py
@@ -82,7 +82,7 @@ def test_log_step(capsys, test_df):
     assert print_statements[2].startswith("[do_something(df)]")
 
 def test_log_step_display_args(capsys, test_df):
-    """Test that we can disable printing function arguments in the log_step""
+    """Test that we can disable printing function arguments in the log_step"""
 
     @log_step(display_args=False)
     def do_something(df):

--- a/tests/test_pandas_utils/test_pandas_utils.py
+++ b/tests/test_pandas_utils/test_pandas_utils.py
@@ -81,6 +81,26 @@ def test_log_step(capsys, test_df):
     assert print_statements[1].startswith("[do_nothing(df, kwargs = {'a': '1'})]")
     assert print_statements[2].startswith("[do_something(df)]")
 
+def test_log_step_display_args(capsys, test_df):
+    """Base test of log_step without any arguments to the logger"""
+
+    @log_step(display_args=False)
+    def do_something(df):
+        return df.drop(0)
+
+    @log_step
+    def do_nothing(df, *args, **kwargs):
+        return df
+
+    (test_df.pipe(do_nothing).pipe(do_nothing, a="1").pipe(do_something))
+
+    captured = capsys.readouterr()
+    print_statements = captured.out.split("\n")
+
+    assert print_statements[0].startswith("[do_nothing(df)]")
+    assert "kwargs = {'a': '1'}" not in print_statements[1]
+    assert print_statements[2].startswith("[do_something(df)]")
+
 
 def test_log_step_logger(caplog, test_df):
     """Base test of log_step with a logger supplied instead of default print"""

--- a/tests/test_pandas_utils/test_pandas_utils.py
+++ b/tests/test_pandas_utils/test_pandas_utils.py
@@ -82,7 +82,7 @@ def test_log_step(capsys, test_df):
     assert print_statements[2].startswith("[do_something(df)]")
 
 def test_log_step_display_args(capsys, test_df):
-    """Base test of log_step without any arguments to the logger"""
+    """Test that we can disable printing function arguments in the log_step""
 
     @log_step(display_args=False)
     def do_something(df):

--- a/tests/test_pandas_utils/test_pandas_utils.py
+++ b/tests/test_pandas_utils/test_pandas_utils.py
@@ -98,6 +98,7 @@ def test_log_step_display_args(capsys, test_df):
     print_statements = captured.out.split("\n")
 
     assert print_statements[0].startswith("[do_nothing(df)]")
+    raise Exception(print_statements[1])
     assert "kwargs = {'a': '1'}" not in print_statements[1]
     assert print_statements[2].startswith("[do_something(df)]")
 


### PR DESCRIPTION
One of my pipeline steps (that I wanted to log) actually performs a merge operation, which led to some extensive debug output because it basically printed the head() of the "right" dataframe. It would be helpful to be able to disable that behavior.