### PR TITLE
Update documentation dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ all_packages = cvxpy_packages
 
 docs_packages = [
     "sphinx==1.8.5",
-    "sphinx_rtd_theme>=0.4.3",
+    "sphinx_rtd_theme>=1.0.0",
     "nbsphinx>=0.4.2",
     "recommonmark==0.6.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,9 @@ cvxpy_packages = ["cvxpy>=1.1.8"]
 all_packages = cvxpy_packages
 
 docs_packages = [
-    "sphinx==1.8.5",
+    "sphinx==4.5.0",
     "sphinx_rtd_theme>=1.0.0",
-    "nbsphinx>=0.4.2",
-    "recommonmark==0.6.0",
+    "nbsphinx>=0.8.8",
 ]
 test_packages = all_packages + [  # we need extras packages for their tests
     "flake8>=3.6.0",

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,9 @@ all_packages = cvxpy_packages
 
 docs_packages = [
     "sphinx==4.5.0",
-    "sphinx_rtd_theme>=1.0.0",
-    "nbsphinx>=0.8.8",
+    "sphinx_rtd_theme==1.0.0",
+    "nbsphinx==0.8.8",
+    "recommonmark==0.7.1"
 ]
 test_packages = all_packages + [  # we need extras packages for their tests
     "flake8>=3.6.0",


### PR DESCRIPTION
It's about time. The versions we use are from 2019 and are causing build issues in https://github.com/koaning/scikit-lego/pull/503.