### PR TITLE
No longer check arrays in Thresholder

### DIFF
--- a/sklego/meta/thresholder.py
+++ b/sklego/meta/thresholder.py
@@ -51,7 +51,6 @@ class Thresholder(BaseEstimator, ClassifierMixin):
         :param sample_weight: array-like, shape=(n_samples) Individual weights for each sample.
         :return: Returns an instance of self.
         """
-        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         self.estimator_ = self.model
         if not isinstance(self.estimator_, ProbabilisticClassifier):
             raise ValueError(

--- a/sklego/meta/thresholder.py
+++ b/sklego/meta/thresholder.py
@@ -5,9 +5,7 @@ from sklearn.base import (
     ClassifierMixin,
 )
 from sklearn.utils.validation import (
-    check_is_fitted,
-    check_X_y,
-    FLOAT_DTYPES,
+    check_is_fitted
 )
 from sklearn.exceptions import NotFittedError
 

--- a/tests/test_meta/test_thresholder.py
+++ b/tests/test_meta/test_thresholder.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 from sklearn.linear_model import LogisticRegression, LinearRegression
+from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.dummy import DummyClassifier
 from sklearn.ensemble import StackingClassifier
 from sklego.common import flatten
@@ -20,6 +21,7 @@ from tests.conftest import general_checks, classifier_checks, select_tests
             "check_classifiers_classes",
             "check_classifiers_train",
             "check_supervised_y_2d",
+            "check_classifier_data_not_an_array", # https://github.com/koaning/scikit-lego/issues/490
         ]
         # outliers train wont work because we have two thresholds
     ),

--- a/tests/test_meta/test_thresholder.py
+++ b/tests/test_meta/test_thresholder.py
@@ -1,7 +1,6 @@
 import pytest
 import numpy as np
 from sklearn.linear_model import LogisticRegression, LinearRegression
-from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.dummy import DummyClassifier
 from sklearn.ensemble import StackingClassifier
 from sklego.common import flatten

--- a/tests/test_meta/test_thresholder.py
+++ b/tests/test_meta/test_thresholder.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.linear_model import LogisticRegression, LinearRegression
 from sklearn.dummy import DummyClassifier
 from sklearn.ensemble import StackingClassifier
@@ -150,3 +151,10 @@ def test_stacking_classifier():
     a = Thresholder(clf, threshold=0.2)
     a.fit(X, y)
     a.predict(X)
+
+
+def test_nans_could_work():
+    X = np.array([[np.nan, 4], [7, 3], [5, 5], [7, 2], [5, 7]])
+    y = np.array([1, 0, 1, 0, 1])
+    model = Thresholder(HistGradientBoostingClassifier(), 0.6)
+    model.fit(X, y)


### PR DESCRIPTION
This PR fixes https://github.com/koaning/scikit-lego/issues/490 and https://github.com/koaning/scikit-lego/issues/497. 