### PR TITLE
Propagate check_X in predict methods of GroupedPredictor

### DIFF
--- a/sklego/meta/grouped_predictor.py
+++ b/sklego/meta/grouped_predictor.py
@@ -339,7 +339,7 @@ class GroupedPredictor(BaseEstimator):
         check_is_fitted(self, ["estimators_", "groups_", "fallback_"])
 
         X_group, X_value = _split_groups_and_values(
-            X, self.groups, min_value_cols=0, **self._check_kwargs
+            X, self.groups, min_value_cols=0, check_X=self.check_X, **self._check_kwargs
         )
 
         X_group = self.__add_shrinkage_column(X_group)
@@ -362,7 +362,7 @@ class GroupedPredictor(BaseEstimator):
         check_is_fitted(self, ["estimators_", "groups_", "fallback_"])
 
         X_group, X_value = _split_groups_and_values(
-            X, self.groups, min_value_cols=0, **self._check_kwargs
+            X, self.groups, min_value_cols=0, check_X=self.check_X, **self._check_kwargs
         )
 
         X_group = self.__add_shrinkage_column(X_group)
@@ -387,7 +387,7 @@ class GroupedPredictor(BaseEstimator):
         check_is_fitted(self, ["estimators_", "groups_", "fallback_"])
 
         X_group, X_value = _split_groups_and_values(
-            X, self.groups, min_value_cols=0, **self._check_kwargs
+            X, self.groups, min_value_cols=0, check_X=self.check_X, **self._check_kwargs
         )
 
         X_group = self.__add_shrinkage_column(X_group)

--- a/tests/test_meta/test_grouped_predictor.py
+++ b/tests/test_meta/test_grouped_predictor.py
@@ -551,7 +551,8 @@ def test_missing_check():
     model =  make_pipeline(SimpleImputer(), LinearRegression())
 
     # Should not raise error, check is disabled
-    GroupedPredictor(model, groups = ['diet'], check_X = False).fit(X, y)
+    m = GroupedPredictor(model, groups = ['diet'], check_X = False).fit(X, y)
+    m.predict(X)
 
     # Should raise error, check is still enabled
     with pytest.raises(ValueError) as e:
@@ -560,7 +561,7 @@ def test_missing_check():
 
 
 def test_has_decision_function():
-    # needed as for example cross_val_score(pipe, X, y, cv=5, scoring="roc_auc", error_score='raise') may fail otherwise, see https://github.com/koaning/scikit-lego/issues/511 
+    # needed as for example cross_val_score(pipe, X, y, cv=5, scoring="roc_auc", error_score='raise') may fail otherwise, see https://github.com/koaning/scikit-lego/issues/511
     df = load_chicken(as_frame=True)
 
     X, y = df.drop(columns='weight'),  df['weight']


### PR DESCRIPTION
# Context

Closes #520 . An earlier change exposed a parameter `check_X` in `GroupedPredictor` to optionally disable a conversion to a float array (which is required for compatibility with _most_ sklearn predictors). However, there are some predictors which handle missing values and even string variables directly (e.g. CatBoostClassifier for example). `check_X` allows usage of data which cannot be converted to a float array.

As described in #520, there is a small bug where `check_X` is not used when `predict` functions are called. As such, you can currently _fit_ a model with non-float array data, but you cannot predict on non-float array data.

# Change

Propagate `self.check_X` in `GroupedPredictor` to predict-like calls. This includes:

- `predict`
- `predict_proba`
- `decision_function`

# Testing
The extension to the test `tests/test_meta/test_grouped_predictor.py::test_missing_check` initially fails with:

```
FAILED tests/test_meta/test_grouped_predictor.py::test_missing_check - ValueError: Input contains NaN.
```

After implementation, all tests pass.