### PR TITLE
typo fixes

### DIFF
--- a/doc/meta.ipynb
+++ b/doc/meta.ipynb
@@ -783,7 +783,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's consider the number 0.2346 in the lower left corner. This number represents the probability that the actually class 0 while the model predicts class 1. In math we might write this as $P(C_1 | M_1)$ where $C_i$ denotes the actual label while $M_i$ denotes the label given by the algorithm. \n",
+    "Let's consider the number 0.1359 in the lower left corner. This number represents the probability that the actually class 0 while the model predicts class 1. In math we might write this as $P(C_1 | M_1)$ where $C_i$ denotes the actual label while $M_i$ denotes the label given by the algorithm. \n",
     "\n",
     "The idea now is that we might rebalance our original predictions $P(M_i)$ by multiplying them;\n",
     "\n",

--- a/doc/preprocessing.ipynb
+++ b/doc/preprocessing.ipynb
@@ -250,7 +250,7 @@
     "\n",
     "Some models are great at interpolation but less good at extrapolation.\n",
     "One way to potentially circumvent this problem is by capping extreme\n",
-    "valeus that occur in the dataset **X**.\n",
+    "values that occur in the dataset **X**.\n",
     "\n",
     "![img3](_static/column-capper.png)\n",
     "\n",


### PR DESCRIPTION
This fixes the meta estimator typo mentioned in issue #516 and a small typo in preprocessing. Also, it remedies the mess I made in PR #522 -- images remain unchanged and the diffs are nice an clean. We can close the other PR, apologies for that. 