### PR TITLE
Pass kwargs to `fit` method of `EstimatorTransformer`.

### DIFF
--- a/sklego/meta/estimator_transformer.py
+++ b/sklego/meta/estimator_transformer.py
@@ -23,12 +23,12 @@ class EstimatorTransformer(TransformerMixin, MetaEstimatorMixin, BaseEstimator):
         self.estimator = estimator
         self.predict_func = predict_func
 
-    def fit(self, X, y, *args, **kwargs):
+    def fit(self, X, y, **kwargs):
         """Fits the estimator"""
         X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES, multi_output=True)
         self.multi_output_ = len(y.shape) > 1
         self.estimator_ = clone(self.estimator)
-        self.estimator_.fit(X, y, *args, **kwargs)
+        self.estimator_.fit(X, y, **kwargs)
         return self
 
     def transform(self, X):

--- a/sklego/meta/estimator_transformer.py
+++ b/sklego/meta/estimator_transformer.py
@@ -23,12 +23,12 @@ class EstimatorTransformer(TransformerMixin, MetaEstimatorMixin, BaseEstimator):
         self.estimator = estimator
         self.predict_func = predict_func
 
-    def fit(self, X, y):
+    def fit(self, X, y, *args, **kwargs):
         """Fits the estimator"""
         X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES, multi_output=True)
         self.multi_output_ = len(y.shape) > 1
         self.estimator_ = clone(self.estimator)
-        self.estimator_.fit(X, y)
+        self.estimator_.fit(X, y, *args, **kwargs)
         return self
 
     def transform(self, X):

--- a/tests/test_meta/test_estimatortransformer.py
+++ b/tests/test_meta/test_estimatortransformer.py
@@ -75,6 +75,7 @@ def test_shape(random_xy_dataset_regr):
 def test_shape_multitarget(random_xy_dataset_multitarget):
     X, y = random_xy_dataset_multitarget
     m = X.shape[0]
+    print('hello')
     n = y.shape[1]
     pipeline = Pipeline(
         [
@@ -98,9 +99,14 @@ def test_kwargs(random_xy_dataset_clf):
             )
         ]
     )
-    # If the additional parameter sample_weight is passed transform_no_kwargs and transform_kwargs should not be equal.
     transform_no_kwargs = pipeline.fit(X, y).transform(X)
-    transform_kwargs = pipeline.fit(X, y, model__sample_weight=0.1).transform(X)
+
+    # First sample is weighted twice as much
+    sample_weights = np.ones(shape=len(y))
+    sample_weights[0] = 2
+
+    # If sample_weights are passed transform_no_kwargs and transform_kwargs should not be equal.
+    transform_kwargs = pipeline.fit(X, y, model__sample_weight=sample_weights).transform(X)
     assert not np.array_equal(transform_no_kwargs, transform_kwargs)
 
     # Fitting with sample_weight=1. should be the same as fitting with sample_weight not specified.

--- a/tests/test_meta/test_estimatortransformer.py
+++ b/tests/test_meta/test_estimatortransformer.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+from unittest.mock import Mock
 from sklearn import clone
 from sklearn.dummy import DummyClassifier
 from sklearn.multioutput import MultiOutputRegressor
@@ -91,16 +92,12 @@ def test_kwargs(random_xy_dataset_clf):
     """ Test if kwargs are properly passed to an underlying estimator. """
     X, y = random_xy_dataset_clf
     pipeline = EstimatorTransformer(LinearRegression())
-    transform_no_kwargs = pipeline.fit(X, y).transform(X)
 
     # First sample is weighted twice as much
     sample_weights = np.ones(shape=len(y))
     sample_weights[0] = 2
 
-    # If sample_weights are passed transform_no_kwargs and transform_kwargs should not be equal.
-    transform_kwargs = pipeline.fit(X, y, model__sample_weight=sample_weights).transform(X)
-    assert not np.array_equal(transform_no_kwargs, transform_kwargs)
-
-    # Fitting with sample_weight=1. should be the same as fitting with sample_weight not specified.
-    transform_kwargs2 = pipeline.fit(X, y, model__sample_weight=1.).transform(X)
-    assert np.array_equal(transform_no_kwargs, transform_kwargs2)
+    # Check if fit method is explicitly called with sample weights
+    pipeline.fit = Mock()
+    pipeline.fit(X, y, model__sample_weight=sample_weights)
+    pipeline.fit.assert_called_with(X, y, model__sample_weight=sample_weights)

--- a/tests/test_meta/test_estimatortransformer.py
+++ b/tests/test_meta/test_estimatortransformer.py
@@ -75,7 +75,6 @@ def test_shape(random_xy_dataset_regr):
 def test_shape_multitarget(random_xy_dataset_multitarget):
     X, y = random_xy_dataset_multitarget
     m = X.shape[0]
-    print('hello')
     n = y.shape[1]
     pipeline = Pipeline(
         [

--- a/tests/test_meta/test_estimatortransformer.py
+++ b/tests/test_meta/test_estimatortransformer.py
@@ -102,3 +102,7 @@ def test_kwargs(random_xy_dataset_clf):
     transform_no_kwargs = pipeline.fit(X, y).transform(X)
     transform_kwargs = pipeline.fit(X, y, model__sample_weight=0.1).transform(X)
     assert not np.array_equal(transform_no_kwargs, transform_kwargs)
+
+    # Fitting with sample_weight=1 should be the same as fitting with sample_weight not specified.
+    transform_kwargs2 = pipeline.fit(X, y, model__sample_weight=1.).transform(X)
+    assert np.array_equal(transform_no_kwargs, transform_kwargs2)

--- a/tests/test_meta/test_estimatortransformer.py
+++ b/tests/test_meta/test_estimatortransformer.py
@@ -98,11 +98,11 @@ def test_kwargs(random_xy_dataset_clf):
             )
         ]
     )
-    # If the additional parameter sample_weight is passed transform_no_kwargs and transform_kwargs cannot be equal.
+    # If the additional parameter sample_weight is passed transform_no_kwargs and transform_kwargs should not be equal.
     transform_no_kwargs = pipeline.fit(X, y).transform(X)
     transform_kwargs = pipeline.fit(X, y, model__sample_weight=0.1).transform(X)
     assert not np.array_equal(transform_no_kwargs, transform_kwargs)
 
-    # Fitting with sample_weight=1 should be the same as fitting with sample_weight not specified.
+    # Fitting with sample_weight=1. should be the same as fitting with sample_weight not specified.
     transform_kwargs2 = pipeline.fit(X, y, model__sample_weight=1.).transform(X)
     assert np.array_equal(transform_no_kwargs, transform_kwargs2)

--- a/tests/test_meta/test_estimatortransformer.py
+++ b/tests/test_meta/test_estimatortransformer.py
@@ -90,14 +90,7 @@ def test_shape_multitarget(random_xy_dataset_multitarget):
 def test_kwargs(random_xy_dataset_clf):
     """ Test if kwargs are properly passed to an underlying estimator. """
     X, y = random_xy_dataset_clf
-    pipeline = Pipeline(
-        [
-            (
-                "model",
-                EstimatorTransformer(LinearRegression())
-            )
-        ]
-    )
+    pipeline = EstimatorTransformer(LinearRegression())
     transform_no_kwargs = pipeline.fit(X, y).transform(X)
 
     # First sample is weighted twice as much

--- a/tests/test_meta/test_estimatortransformer.py
+++ b/tests/test_meta/test_estimatortransformer.py
@@ -105,5 +105,3 @@ def test_kwargs(patched_clone, random_xy_dataset_clf):
     np.testing.assert_array_equal(
         sample_weights, estimator.fit.call_args.kwargs['sample_weight']
     )
-
-

--- a/tests/test_meta/test_estimatortransformer.py
+++ b/tests/test_meta/test_estimatortransformer.py
@@ -85,3 +85,20 @@ def test_shape_multitarget(random_xy_dataset_multitarget):
         ]
     )
     assert pipeline.fit(X, y).transform(X).shape == (m, n)
+
+
+def test_kwargs(random_xy_dataset_clf):
+    """ Test if kwargs are properly passed to an underlying estimator. """
+    X, y = random_xy_dataset_clf
+    pipeline = Pipeline(
+        [
+            (
+                "model",
+                EstimatorTransformer(Ridge(random_state=0))
+            )
+        ]
+    )
+    # If the additional parameter sample_weight is passed transform_no_kwargs and transform_kwargs cannot be equal.
+    transform_no_kwargs = pipeline.fit(X, y).transform(X)
+    transform_kwargs = pipeline.fit(X, y, model__sample_weight=0.1).transform(X)
+    assert not np.array_equal(transform_no_kwargs, transform_kwargs)

--- a/tests/test_meta/test_estimatortransformer.py
+++ b/tests/test_meta/test_estimatortransformer.py
@@ -95,7 +95,7 @@ def test_kwargs(random_xy_dataset_clf):
         [
             (
                 "model",
-                EstimatorTransformer(Ridge(random_state=0))
+                EstimatorTransformer(LinearRegression())
             )
         ]
     )

--- a/tests/test_meta/test_estimatortransformer.py
+++ b/tests/test_meta/test_estimatortransformer.py
@@ -103,5 +103,11 @@ def test_kwargs(patched_clone, random_xy_dataset_clf):
     # We can't use `assert_called_with` because that compares by `==` which is ambiguous
     # on numpy arrays
     np.testing.assert_array_equal(
-        sample_weights, estimator.fit.call_args.kwargs['sample_weight']
+        X, estimator.fit.call_args[0][0]
+    )
+    np.testing.assert_array_equal(
+        y, estimator.fit.call_args[0][1]
+    )
+    np.testing.assert_array_equal(
+        sample_weights, estimator.fit.call_args[1]['sample_weight']
     )

--- a/tests/test_meta/test_estimatortransformer.py
+++ b/tests/test_meta/test_estimatortransformer.py
@@ -103,10 +103,10 @@ def test_kwargs(patched_clone, random_xy_dataset_clf):
     # We can't use `assert_called_with` because that compares by `==` which is ambiguous
     # on numpy arrays
     np.testing.assert_array_equal(
-        X, estimator.fit.call_args.args[0]
+        X, estimator.fit.call_args_list[0][0][0]
     )
     np.testing.assert_array_equal(
-        y, estimator.fit.call_args.args[1]
+        y, estimator.fit.call_args_list[0][0][1]
     )
     np.testing.assert_array_equal(
         sample_weights, estimator.fit.call_args.kwargs['sample_weight']

--- a/tests/test_meta/test_estimatortransformer.py
+++ b/tests/test_meta/test_estimatortransformer.py
@@ -103,12 +103,6 @@ def test_kwargs(patched_clone, random_xy_dataset_clf):
     # We can't use `assert_called_with` because that compares by `==` which is ambiguous
     # on numpy arrays
     np.testing.assert_array_equal(
-        X, estimator.fit.call_args_list[0][0][0]
-    )
-    np.testing.assert_array_equal(
-        y, estimator.fit.call_args_list[0][0][1]
-    )
-    np.testing.assert_array_equal(
         sample_weights, estimator.fit.call_args.kwargs['sample_weight']
     )
 


### PR DESCRIPTION
Option to pass along `**kwargs` to underlying estimator in `EstimatorTransformer`. This allows for passing parameters like `sample_weight` in scikit-learn objects and parameters like `eval_set` for XGBoost, Catboost and LightGBM that can only be passed in `.fit()`.

Resolves Issue #530 

scikit-learn describes usage of kwargs for passing optional data-dependent parameters here:
https://scikit-learn.org/stable/developers/develop.html#fitting