### PR TITLE
Alias for `_estimator_type` in `DecayEstimator`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.4.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
@@ -9,7 +9,7 @@ repos:
     -   id: check-merge-conflict
     -   id: check-added-large-files
 -   repo: https://github.com/psf/black
-    rev: stable
+    rev: 23.9.1
     hooks:
     -   id: black
         files: sklego

--- a/sklego/meta/decay_estimator.py
+++ b/sklego/meta/decay_estimator.py
@@ -33,7 +33,7 @@ class DecayEstimator(BaseEstimator):
 
     @property
     def _estimator_type(self):
-        """Estimator type is computed dynamically from the given model."""
+        """Computes `_estimator_type` dynamically from the wrapped model."""
         return self.model._estimator_type
 
     def fit(self, X, y):

--- a/sklego/meta/decay_estimator.py
+++ b/sklego/meta/decay_estimator.py
@@ -31,6 +31,11 @@ class DecayEstimator(BaseEstimator):
             ["ClassifierMixin" in p.__name__ for p in type(self.model).__bases__]
         )
 
+    @property
+    def _estimator_type(self):
+        """Estimator type is computed dynamically from the given model."""
+        return self.model._estimator_type
+
     def fit(self, X, y):
         """
         Fit the data after adapting the same weight.


### PR DESCRIPTION
# Description

Adding a property that aliases the model `_estimator_type` it allows scikit-learn functions such as `is_regressor`, `is_classifier`, `is_outlier_detector` to return the internal state instead of `False`

Fixes #463 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines (flake8)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (also to the readme.md)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added tests to check whether the new feature adheres to the sklearn convention
- [X] New and existing unit tests pass locally with my changes
