### PR TITLE
Relax `check_X_y` for `DecayEstimator`

### DIFF
--- a/sklego/meta/decay_estimator.py
+++ b/sklego/meta/decay_estimator.py
@@ -16,6 +16,9 @@ class DecayEstimator(BaseEstimator):
     This meta estimator will only work for estimators that have a
     "sample_weights" argument in their `.fit()` method.
 
+    The `fit` method computes the weights to pass to the estimator. All the checks are
+    delegated to the wrapped estimator.
+
     The DecayEstimator will use exponential decay to weight the parameters.
 
     w_{t-1} = decay * w_{t}

--- a/sklego/meta/decay_estimator.py
+++ b/sklego/meta/decay_estimator.py
@@ -18,9 +18,9 @@ class DecayEstimator(BaseEstimator):
 
     The `fit` method computes the weights to pass to the estimator.
 
-    .. warning:: By default all the checks on `X` and `y` are delegated to the wrapped estimator.
+    .. warning:: By default all the checks on the inputs `X` and `y` are delegated to the wrapped estimator.
 
-        To change such behaviour, set `check_X_y` to `True`.
+        To change such behaviour, set `check_input` to `True`.
 
         Remark that if the check is skipped, then `y` should have a `shape` attrbute, which is
         used to extract the number of samples in training data, and compute the weights.
@@ -31,12 +31,12 @@ class DecayEstimator(BaseEstimator):
     """
 
     def __init__(
-        self, model, decay: float = 0.999, decay_func="exponential", check_X_y=False
+        self, model, decay: float = 0.999, decay_func="exponential", check_input=False
     ):
         self.model = model
         self.decay = decay
         self.decay_func = decay_func
-        self.check_X_y = check_X_y
+        self.check_input = check_input
 
     def _is_classifier(self):
         return any(
@@ -57,7 +57,7 @@ class DecayEstimator(BaseEstimator):
         :return: Returns an instance of self.
         """
 
-        if self.check_X_y:
+        if self.check_input:
             X, y = check_X_y(
                 X, y, estimator=self, dtype=FLOAT_DTYPES, ensure_min_features=0
             )

--- a/sklego/meta/decay_estimator.py
+++ b/sklego/meta/decay_estimator.py
@@ -44,8 +44,10 @@ class DecayEstimator(BaseEstimator):
         :param y: array-like, shape=(n_samples,) training data.
         :return: Returns an instance of self.
         """
-        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
-        self.weights_ = np.cumprod(np.ones(X.shape[0]) * self.decay)[::-1]
+        X, y = check_X_y(
+            X, y, estimator=self, dtype=FLOAT_DTYPES, ensure_min_features=0
+        )
+        self.weights_ = np.cumprod(np.ones(y.shape[0]) * self.decay)[::-1]
         self.estimator_ = clone(self.model)
         try:
             self.estimator_.fit(X, y, sample_weight=self.weights_)

--- a/sklego/meta/decay_estimator.py
+++ b/sklego/meta/decay_estimator.py
@@ -16,18 +16,27 @@ class DecayEstimator(BaseEstimator):
     This meta estimator will only work for estimators that have a
     "sample_weights" argument in their `.fit()` method.
 
-    The `fit` method computes the weights to pass to the estimator. All the checks are
-    delegated to the wrapped estimator.
+    The `fit` method computes the weights to pass to the estimator.
+
+    .. warning:: By default all the checks on `X` and `y` are delegated to the wrapped estimator.
+
+        To change such behaviour, set `check_X_y` to `True`.
+
+        Remark that if the check is skipped, then `y` should have a `shape` attrbute, which is
+        used to extract the number of samples in training data, and compute the weights.
 
     The DecayEstimator will use exponential decay to weight the parameters.
 
     w_{t-1} = decay * w_{t}
     """
 
-    def __init__(self, model, decay: float = 0.999, decay_func="exponential"):
+    def __init__(
+        self, model, decay: float = 0.999, decay_func="exponential", check_X_y=False
+    ):
         self.model = model
         self.decay = decay
         self.decay_func = decay_func
+        self.check_X_y = check_X_y
 
     def _is_classifier(self):
         return any(
@@ -43,13 +52,16 @@ class DecayEstimator(BaseEstimator):
         """
         Fit the data after adapting the same weight.
 
-        :param X: array-like, shape=(n_columns, n_samples,) training data.
-        :param y: array-like, shape=(n_samples,) training data.
+        :param X: array-like, shape=(n_samples, n_features,) training data.
+        :param y: array-like, shape=(n_samples,) target values.
         :return: Returns an instance of self.
         """
-        X, y = check_X_y(
-            X, y, estimator=self, dtype=FLOAT_DTYPES, ensure_min_features=0
-        )
+
+        if self.check_X_y:
+            X, y = check_X_y(
+                X, y, estimator=self, dtype=FLOAT_DTYPES, ensure_min_features=0
+            )
+
         self.weights_ = np.cumprod(np.ones(y.shape[0]) * self.decay)[::-1]
         self.estimator_ = clone(self.model)
         try:
@@ -67,7 +79,7 @@ class DecayEstimator(BaseEstimator):
         """
         Predict new data.
 
-        :param X: array-like, shape=(n_columns, n_samples,) training data.
+        :param X: array-like, shape=(n_samples, n_features,) data to predict.
         :return: array, shape=(n_samples,) the predicted data
         """
         if self._is_classifier():

--- a/tests/test_meta/test_decay_estimator.py
+++ b/tests/test_meta/test_decay_estimator.py
@@ -17,13 +17,13 @@ from tests.conftest import (
 
 @pytest.mark.parametrize("test_fn", flatten([general_checks, regressor_checks]))
 def test_estimator_checks_regression(test_fn):
-    trf = DecayEstimator(LinearRegression(), check_X_y=True)
+    trf = DecayEstimator(LinearRegression(), check_input=True)
     test_fn(DecayEstimator.__name__, trf)
 
 
 @pytest.mark.parametrize("test_fn", flatten([general_checks, classifier_checks]))
 def test_estimator_checks_classification(test_fn):
-    trf = DecayEstimator(LogisticRegression(solver="lbfgs"), check_X_y=True)
+    trf = DecayEstimator(LogisticRegression(solver="lbfgs"), check_input=True)
     test_fn(DecayEstimator.__name__, trf)
 
 

--- a/tests/test_meta/test_decay_estimator.py
+++ b/tests/test_meta/test_decay_estimator.py
@@ -17,13 +17,13 @@ from tests.conftest import (
 
 @pytest.mark.parametrize("test_fn", flatten([general_checks, regressor_checks]))
 def test_estimator_checks_regression(test_fn):
-    trf = DecayEstimator(LinearRegression())
+    trf = DecayEstimator(LinearRegression(), check_X_y=True)
     test_fn(DecayEstimator.__name__, trf)
 
 
 @pytest.mark.parametrize("test_fn", flatten([general_checks, classifier_checks]))
 def test_estimator_checks_classification(test_fn):
-    trf = DecayEstimator(LogisticRegression(solver="lbfgs"))
+    trf = DecayEstimator(LogisticRegression(solver="lbfgs"), check_X_y=True)
     test_fn(DecayEstimator.__name__, trf)
 
 


### PR DESCRIPTION
# Description

Relaxes the check for `X` in `DecayEstimator` by delegating the actual checks to the given estimator. This fixes #573 and allows estimators that do not need `X` features. 
Remark, as discussed in the issue, it may be worth it to completely remove the check.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [X] My code follows the style guidelines (flake8)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (also to the readme.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added tests to check whether the new feature adheres to the sklearn convention
- [X] New and existing unit tests pass locally with my changes
