### PR TITLE
Passing labels when calling pd.DataFrame predict_proba and classificiation

### DIFF
--- a/sklego/meta/grouped_predictor.py
+++ b/sklego/meta/grouped_predictor.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 from sklearn import clone
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, is_classifier
 from sklearn.utils.metaestimators import available_if
 from sklearn.utils.validation import (
     check_is_fitted,
@@ -282,6 +282,8 @@ class GroupedPredictor(BaseEstimator):
         """Predict a single group by getting its estimator from the fitted dict"""
         # Keep track of the original index such that we can sort in __predict_groups
         index = X.index
+        extra_kwargs = {}
+
         try:
             group_predictor = self.estimators_[group]
         except KeyError:
@@ -292,9 +294,15 @@ class GroupedPredictor(BaseEstimator):
                     f"Found new group {group} during predict with use_global_model = False"
                 )
 
+        # Ensure to mantain label order if it's called with predict_proba
+        if is_classifier(group_predictor) and method == "predict_proba":
+            extra_kwargs = {"columns": group_predictor.classes_}
+
         # getattr(group_predictor, method) returns the predict method of the fitted model
         # if the method argument is "predict" and the predict_proba method if method argument is "predict_proba"
-        return pd.DataFrame(getattr(group_predictor, method)(X)).set_index(index)
+        return pd.DataFrame(
+            getattr(group_predictor, method)(X), **extra_kwargs
+        ).set_index(index)
 
     def __predict_groups(
         self,
@@ -350,7 +358,7 @@ class GroupedPredictor(BaseEstimator):
             return self.__predict_shrinkage_groups(X_group, X_value, method="predict")
 
     # This ensures that the meta-estimator only has the predict_proba method if the estimator has it
-    @available_if(lambda self: hasattr(self.estimator, 'predict_proba'))
+    @available_if(lambda self: hasattr(self.estimator, "predict_proba"))
     def predict_proba(self, X):
         """
         Predict probabilities on new data.
@@ -375,7 +383,7 @@ class GroupedPredictor(BaseEstimator):
             )
 
     # This ensures that the meta-estimator only has the predict_proba method if the estimator has it
-    @available_if(lambda self: hasattr(self.estimator, 'decision_function'))
+    @available_if(lambda self: hasattr(self.estimator, "decision_function"))
     def decision_function(self, X):
         """
         Evaluate the decision function for the samples in X.

--- a/sklego/meta/grouped_predictor.py
+++ b/sklego/meta/grouped_predictor.py
@@ -330,8 +330,8 @@ class GroupedPredictor(BaseEstimator):
                     for group, indices in group_indices.items()
                 ],
                 axis=0,
-                # Fill with prob = 0 impossible labels
             )
+            # Fill with prob = 0 for impossible labels in predict_proba
             .fillna(0)
             .sort_index()
             .values.squeeze()

--- a/tests/test_meta/test_grouped_predictor.py
+++ b/tests/test_meta/test_grouped_predictor.py
@@ -152,9 +152,7 @@ def test_predict_proba_correct_zeros_same_and_different_labels(
 
     # Ensure for the common labels there are no zeros
     in_common_labels = labels_a.intersection(labels_b)
-    for _, grp in df_proba.groupby("group"):
-        for label in in_common_labels:
-            assert (grp.loc[:, label] != 0).all()
+    assert all((df_proba.loc[:, label] != 0).all() for label in in_common_labels)
 
     # Ensure for the non common labels there are only zeros
     label_not_in_group = {
@@ -162,8 +160,9 @@ def test_predict_proba_correct_zeros_same_and_different_labels(
         "B": list(labels_a.difference(labels_b)),
     }
     for grp_name, grp in df_proba.groupby("group"):
-        for _grp in label_not_in_group[grp_name]:
-            assert (grp.loc[:, _grp] == 0).all()
+        assert all(
+            (grp.loc[:, label] == 0).all() for label in label_not_in_group[grp_name]
+        )
 
 
 def test_fallback_can_raise_error():

--- a/tests/test_meta/test_grouped_predictor.py
+++ b/tests/test_meta/test_grouped_predictor.py
@@ -57,15 +57,6 @@ def test_estimator_checks(test_fn):
     test_fn(GroupedPredictor.__name__ + "_nofallback", clf)
 
 
-@pytest.fixture
-def dataset():
-    np.random.seed(42)
-    n = 100
-    inputs = np.concatenate([np.ones((n, 1)), np.random.normal(0, 1, (n, 1))], axis=1)
-    targets = 3.1 * inputs[:, 0] + 2.0 * inputs[:, 1]
-    return inputs, targets
-
-
 def test_chickweight_df1_keys():
     df = load_chicken(as_frame=True)
     mod = GroupedPredictor(estimator=LinearRegression(), groups="diet")

--- a/tests/test_meta/test_grouped_predictor.py
+++ b/tests/test_meta/test_grouped_predictor.py
@@ -13,26 +13,8 @@ from sklego.datasets import load_chicken
 from tests.conftest import general_checks, select_tests
 
 
-@pytest.fixture(name="df_predict_proba")
-def get_df_different_classes_classification():
-
-    np.random.seed(43)
-    group_size = 5
-    n_groups = 2
-
-    group_col = np.repeat(["A", "B"], group_size)
-    x_col = np.random.normal(size=group_size * n_groups)
-    y_col = np.hstack(
-        [
-            np.random.choice([0, 1, 2], size=group_size),
-            np.random.choice([0, 2], size=group_size),
-        ]
-    )
-    df = pd.DataFrame({"group": group_col, "x": x_col, "y": y_col})
-    return df
-
-@pytest.fixture(name="df_predict_proba_request")
-def my_custom_df(request):
+@pytest.fixture
+def random_xy_grouped_clf_different_classes(request):
     group_size = request.param.get("group_size")
     y_choices_grpa = request.param.get("y_choices_grpa")
     y_choices_grpb = request.param.get("y_choices_grpb")
@@ -48,6 +30,7 @@ def my_custom_df(request):
     )
     df = pd.DataFrame({"group": group_col, "x": x_col, "y": y_col})
     return df
+
 
 @pytest.mark.parametrize(
     "test_fn",
@@ -108,43 +91,78 @@ def test_chickweight_can_do_fallback_proba():
     assert mod.predict_proba(to_predict).shape == (2, 2)
     assert (mod.predict_proba(to_predict)[0] == mod.predict_proba(to_predict)[1]).all()
 
-@pytest.mark.parametrize("df_predict_proba_request", [
-    {"group_size": 10, "y_choices_grpa": [0, 1, 2], "y_choices_grpb": [0, 1, 2, 4]},
-    {"group_size": 10, "y_choices_grpa": [0, 2], "y_choices_grpb": [0, 2]},
-    {"group_size": 10, "y_choices_grpa": [0, 1, 2, 3], "y_choices_grpb": [0, 4]},
-    {"group_size": 10, "y_choices_grpa": [0, 1, 2], "y_choices_grpb": [0, 3]},
-], indirect=True)
-def test_predict_proba_has_same_columns_as_distinct_labels(df_predict_proba_request):
-    mod = GroupedPredictor(estimator=LogisticRegression(), groups='group')
-    X, y = df_predict_proba_request[["group", "x"]], df_predict_proba_request["y"]
+
+@pytest.mark.parametrize(
+    "random_xy_grouped_clf_different_classes",
+    [
+        {"group_size": 10, "y_choices_grpa": [0, 1, 2], "y_choices_grpb": [0, 1, 2, 4]},
+        {"group_size": 10, "y_choices_grpa": [0, 2], "y_choices_grpb": [0, 2]},
+        {"group_size": 10, "y_choices_grpa": [0, 1, 2, 3], "y_choices_grpb": [0, 4]},
+        {"group_size": 10, "y_choices_grpa": [0, 1, 2], "y_choices_grpb": [0, 3]},
+    ],
+    indirect=True,
+)
+def test_predict_proba_has_same_columns_as_distinct_labels(
+    random_xy_grouped_clf_different_classes,
+):
+    mod = GroupedPredictor(estimator=LogisticRegression(), groups="group")
+    X, y = (
+        random_xy_grouped_clf_different_classes[["group", "x"]],
+        random_xy_grouped_clf_different_classes["y"],
+    )
     _ = mod.fit(X, y)
     y_proba = mod.predict_proba(X)
 
     # Ensure the number of col output is always equal to the cardinality of the labels
-    assert(len(df_predict_proba_request['y'].unique()) == y_proba.shape[1])
+    assert (
+        len(random_xy_grouped_clf_different_classes["y"].unique()) == y_proba.shape[1]
+    )
 
-def test_predict_proba_correct_nulls_different_labels(df_predict_proba):
-    mod = GroupedPredictor(estimator=LogisticRegression(), groups='group')
-    X, y = df_predict_proba[["group", "x"]], df_predict_proba["y"]
+
+@pytest.mark.parametrize(
+    "random_xy_grouped_clf_different_classes",
+    [
+        {"group_size": 5, "y_choices_grpa": [0, 1, 2], "y_choices_grpb": [0, 2]},
+    ],
+    indirect=True,
+)
+def test_predict_proba_correct_nulls_different_labels(
+    random_xy_grouped_clf_different_classes,
+):
+    mod = GroupedPredictor(estimator=LogisticRegression(), groups="group")
+    X, y = (
+        random_xy_grouped_clf_different_classes[["group", "x"]],
+        random_xy_grouped_clf_different_classes["y"],
+    )
     _ = mod.fit(X, y)
     y_proba = mod.predict_proba(X)
 
-    # Ensure there are 5 null values for column 1
+    # Ensure there are 5-zero values for column 1
     col_1 = y_proba[:, 1]
-    assert(np.isnan(col_1).sum() == 5)
+    assert len(col_1[col_1 == 0]) == 5
 
-def test_predict_proba_correct_nulls_same_labels(df_predict_proba):
-    mod = GroupedPredictor(estimator=LogisticRegression(), groups='group')
+
+@pytest.mark.parametrize(
+    "random_xy_grouped_clf_different_classes",
+    [
+        {"group_size": 5, "y_choices_grpa": [0, 1, 2], "y_choices_grpb": [0, 2]},
+    ],
+    indirect=True,
+)
+def test_predict_proba_correct_nulls_same_labels(
+    random_xy_grouped_clf_different_classes,
+):
+    mod = GroupedPredictor(estimator=LogisticRegression(), groups="group")
 
     # Drop label present only in group B
-    df = df_predict_proba.loc[lambda x: x['y']!=1]
+    df = random_xy_grouped_clf_different_classes.loc[lambda x: x["y"] != 1]
     X, y = df[["group", "x"]], df["y"]
     _ = mod.fit(X, y)
     y_proba = mod.predict_proba(X)
 
     # Ensure there are 0 null values for column 1
     col_1 = y_proba[:, 1]
-    assert(np.isnan(col_1).sum() == 0)
+    assert np.isnan(col_1).sum() == 0
 
 
 def test_fallback_can_raise_error():


### PR DESCRIPTION
# Description

When calling **__predict_single_group** method with argument _method_ == _'predict_proba'_ ensure that the model is a classifier.
If yes,  pass as _extra_kwargs_ to **pd.DataFrame** columns = labels of the model. 

This is a non-breaking change that solves an inconsistency using **predict_proba** with sub groups with different labels.


Fixes # [[BUG] GroupedPredictor inconsistency for predict_proba having different classes per group](https://github.com/koaning/scikit-lego/issues/579)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [ ] My code follows the style guidelines (flake8)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (also to the readme.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added tests to check whether the new feature adheres to the sklearn convention
- [x] New and existing unit tests pass locally with my changes

Fixes #579 
