### PR TITLE
Docstrings standardization

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -43,7 +43,8 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'nbsphinx',
-    'recommonmark'
+    'recommonmark',
+    'numpydoc'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,0 +1,129 @@
+# Project information
+site_name: scikit-lego
+
+# Repository information
+repo_name: koaning/scikit-lego
+repo_url: https://github.com/koaning/scikit-lego
+edit_uri: edit/main/docs/
+
+# Configuration
+watch:
+  - sklego
+
+docs_dir: mkdocs
+
+use_directory_urls: true
+theme:
+  name: material
+  logo: _static/logo.png
+  favicon: _static/logo.png
+  font:
+    text: Ubuntu
+    code: Ubuntu Mono
+  highlightjs: true
+  hljs_languages:
+    - bash
+    - python
+    - r
+  features:
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.expand
+    - navigation.path
+    - navigation.indexes
+    - navigation.footer
+    - navigation.top
+    - navigation.tracking
+
+    - content.action.edit
+    - content.action.view
+    - content.code.annotate
+    - content.code.copy
+    - content.tooltips
+    - content.tabs.link
+
+    - search.suggest
+    - search.highlight
+    - search.share
+
+    - toc.follow
+  
+# Plugins
+plugins:
+  - autorefs
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: numpy
+            docstring_section_style: table # table, list or spacy
+            filters:
+            - "!^_"  # Hide semi-private functions and methods
+            - "!^__"  # Hide private functions and methods
+  - search:
+      separator: '[\s\-,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'
+
+# Extensions
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - codehilite
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.snippets:
+      check_paths: true
+  - pymdownx.caret
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.magiclink:
+      repo_url_shorthand: true
+      user: squidfunk
+      repo: mkdocs-material
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
+  - pymdownx.snippets
+
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+
+nav:
+  - Home: index.md
+  - API Reference:
+    - Base: api/base.md
+    - Common: api/common.md
+    - Datasets: api/datasets.md
+    - Decomposition: api/decomposition.md
+    - Dummy: api/dummy.md
+    - Linear Model: api/linear-model.md
+    - Meta: api/meta.md
+    - Metrics: api/metrics.md
+    - Mixture: api/mixture.md
+    - Model Selection: api/model-selection.md
+    - Naive Bayes: api/naive-bayes.md
+    - Neighbors: api/neighbors.md
+    - Pandas Utils: api/pandas-utils.md
+    - Pipeline: api/pipeline.md
+    - Preprocessing: api/preprocessing.md

--- a/mkdocs/api/base.md
+++ b/mkdocs/api/base.md
@@ -2,30 +2,30 @@
 
 ::: sklego.base.ClustererMeta
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.base.Clusterer
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.base.OutlierModelMeta
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.base.OutlierModel
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.base.ProbabilisticClassifierMeta
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.base.ProbabilisticClassifier
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true

--- a/mkdocs/api/base.md
+++ b/mkdocs/api/base.md
@@ -1,0 +1,31 @@
+# Base
+
+::: sklego.base.ClustererMeta
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.base.Clusterer
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.base.OutlierModelMeta
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.base.OutlierModel
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.base.ProbabilisticClassifierMeta
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.base.ProbabilisticClassifier
+    options:
+        show_root_full_path: false
+        show_root_heading: true

--- a/mkdocs/api/common.md
+++ b/mkdocs/api/common.md
@@ -4,25 +4,25 @@ Module with common classes and functions used across the package.
 
 ::: sklego.common.TrainOnlyTransformerMixin
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.common.as_list
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.common.flatten
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.common.expanding_list
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.common.sliding_window
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true

--- a/mkdocs/api/common.md
+++ b/mkdocs/api/common.md
@@ -1,0 +1,28 @@
+# Common
+
+Module with common classes and functions used across the package.
+
+::: sklego.common.TrainOnlyTransformerMixin
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.common.as_list
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.common.flatten
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.common.expanding_list
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.common.sliding_window
+    options:
+        show_root_full_path: false
+        show_root_heading: true

--- a/mkdocs/api/datasets.md
+++ b/mkdocs/api/datasets.md
@@ -1,0 +1,41 @@
+# Datasets
+
+::: sklego.datasets.load_abalone
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.datasets.load_arrests
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.datasets.load_chicken
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.datasets.load_heroes
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.datasets.load_hearts
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.datasets.load_penguins
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.datasets.make_simpleseries
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.datasets.fetch_creditcard
+    options:
+        show_root_full_path: false
+        show_root_heading: true

--- a/mkdocs/api/datasets.md
+++ b/mkdocs/api/datasets.md
@@ -2,40 +2,40 @@
 
 ::: sklego.datasets.load_abalone
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.datasets.load_arrests
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.datasets.load_chicken
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.datasets.load_heroes
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.datasets.load_hearts
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.datasets.load_penguins
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.datasets.make_simpleseries
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.datasets.fetch_creditcard
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true

--- a/mkdocs/api/decomposition.md
+++ b/mkdocs/api/decomposition.md
@@ -1,0 +1,11 @@
+# Decomposition
+
+::: sklego.decomposition.pca_reconstruction.PCAOutlierDetection
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.decomposition.umap_reconstruction.UMAPOutlierDetection
+    options:
+        show_root_full_path: false
+        show_root_heading: true

--- a/mkdocs/api/decomposition.md
+++ b/mkdocs/api/decomposition.md
@@ -2,10 +2,10 @@
 
 ::: sklego.decomposition.pca_reconstruction.PCAOutlierDetection
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.decomposition.umap_reconstruction.UMAPOutlierDetection
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true

--- a/mkdocs/api/dummy.md
+++ b/mkdocs/api/dummy.md
@@ -2,5 +2,5 @@
 
 ::: sklego.dummy.RandomRegressor
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true

--- a/mkdocs/api/dummy.md
+++ b/mkdocs/api/dummy.md
@@ -1,0 +1,6 @@
+# Dummy
+
+::: sklego.dummy.RandomRegressor
+    options:
+        show_root_full_path: false
+        show_root_heading: true

--- a/mkdocs/api/linear-model.md
+++ b/mkdocs/api/linear-model.md
@@ -2,45 +2,45 @@
 
 ::: sklego.linear_model.LowessRegression
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.linear_model.ProbWeightRegression
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.linear_model.DeadZoneRegressor
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.linear_model.DemographicParityClassifier
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.linear_model.EqualOpportunityClassifier
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.linear_model.BaseScipyMinimizeRegressor
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.linear_model.ImbalancedLinearRegression
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.linear_model.QuantileRegression
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.linear_model.LADRegression
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true

--- a/mkdocs/api/linear-model.md
+++ b/mkdocs/api/linear-model.md
@@ -1,0 +1,46 @@
+# Linear Models
+
+::: sklego.linear_model.LowessRegression
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.linear_model.ProbWeightRegression
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.linear_model.DeadZoneRegressor
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.linear_model.DemographicParityClassifier
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.linear_model.EqualOpportunityClassifier
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.linear_model.BaseScipyMinimizeRegressor
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.linear_model.ImbalancedLinearRegression
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.linear_model.QuantileRegression
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.linear_model.LADRegression
+    options:
+        show_root_full_path: false
+        show_root_heading: true

--- a/mkdocs/api/meta.md
+++ b/mkdocs/api/meta.md
@@ -2,50 +2,50 @@
 
 ::: sklego.meta.confusion_balancer.ConfusionBalancer
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.meta.decay_estimator.DecayEstimator
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.meta.estimator_transformer.EstimatorTransformer
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.meta.grouped_predictor.GroupedPredictor
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.meta.grouped_transformer.GroupedTransformer
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.meta.outlier_classifier.OutlierClassifier
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.meta.regression_outlier_detector.RegressionOutlierDetector
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.meta.subjective_classifier.SubjectiveClassifier
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.meta.thresholder.Thresholder
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.meta.zero_inflated_regressor.ZeroInflatedRegressor
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true

--- a/mkdocs/api/meta.md
+++ b/mkdocs/api/meta.md
@@ -1,0 +1,51 @@
+# Meta Models
+
+::: sklego.meta.confusion_balancer.ConfusionBalancer
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.meta.decay_estimator.DecayEstimator
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.meta.estimator_transformer.EstimatorTransformer
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.meta.grouped_predictor.GroupedPredictor
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.meta.grouped_transformer.GroupedTransformer
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.meta.outlier_classifier.OutlierClassifier
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.meta.regression_outlier_detector.RegressionOutlierDetector
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.meta.subjective_classifier.SubjectiveClassifier
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.meta.thresholder.Thresholder
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.meta.zero_inflated_regressor.ZeroInflatedRegressor
+    options:
+        show_root_full_path: false
+        show_root_heading: true

--- a/mkdocs/api/metrics.md
+++ b/mkdocs/api/metrics.md
@@ -2,20 +2,20 @@
 
 ::: sklego.metrics.correlation_score
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.metrics.equal_opportunity_score
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.metrics.p_percent_score
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.metrics.subset_score
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true

--- a/mkdocs/api/metrics.md
+++ b/mkdocs/api/metrics.md
@@ -1,0 +1,21 @@
+# Metrics
+
+::: sklego.metrics.correlation_score
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.metrics.equal_opportunity_score
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.metrics.p_percent_score
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.metrics.subset_score
+    options:
+        show_root_full_path: false
+        show_root_heading: true

--- a/mkdocs/api/mixture.md
+++ b/mkdocs/api/mixture.md
@@ -1,0 +1,21 @@
+# Mixture Models
+
+:::sklego.mixture.bayesian_gmm_classifier.BayesianGMMClassifier
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+:::sklego.mixture.bayesian_gmm_detector.BayesianGMMOutlierDetector
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+:::sklego.mixture.gmm_classifier.GMMClassifier
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+:::sklego.mixture.gmm_outlier_detector.GMMOutlierDetector
+    options:
+        show_root_full_path: false
+        show_root_heading: true

--- a/mkdocs/api/mixture.md
+++ b/mkdocs/api/mixture.md
@@ -2,20 +2,20 @@
 
 :::sklego.mixture.bayesian_gmm_classifier.BayesianGMMClassifier
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 :::sklego.mixture.bayesian_gmm_detector.BayesianGMMOutlierDetector
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 :::sklego.mixture.gmm_classifier.GMMClassifier
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 :::sklego.mixture.gmm_outlier_detector.GMMOutlierDetector
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true

--- a/mkdocs/api/model-selection.md
+++ b/mkdocs/api/model-selection.md
@@ -2,15 +2,15 @@
 
 :::sklego.model_selection.GroupTimeSeriesSplit
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 :::sklego.model_selection.KlusterFoldValidation
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 :::sklego.model_selection.TimeGapSplit
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true

--- a/mkdocs/api/model-selection.md
+++ b/mkdocs/api/model-selection.md
@@ -1,0 +1,16 @@
+# Model Selection
+
+:::sklego.model_selection.GroupTimeSeriesSplit
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+:::sklego.model_selection.KlusterFoldValidation
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+:::sklego.model_selection.TimeGapSplit
+    options:
+        show_root_full_path: false
+        show_root_heading: true

--- a/mkdocs/api/naive-bayes.md
+++ b/mkdocs/api/naive-bayes.md
@@ -2,10 +2,10 @@
 
 :::sklego.naive_bayes.GaussianMixtureNB
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 :::sklego.naive_bayes.BayesianGaussianMixtureNB
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true

--- a/mkdocs/api/naive-bayes.md
+++ b/mkdocs/api/naive-bayes.md
@@ -1,0 +1,11 @@
+# Naive Bayes
+
+:::sklego.naive_bayes.GaussianMixtureNB
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+:::sklego.naive_bayes.BayesianGaussianMixtureNB
+    options:
+        show_root_full_path: false
+        show_root_heading: true

--- a/mkdocs/api/neighbors.md
+++ b/mkdocs/api/neighbors.md
@@ -1,0 +1,6 @@
+# Neighbors
+
+:::sklego.neighbors.BayesianKernelDensityClassifier
+    options:
+        show_root_full_path: false
+        show_root_heading: true

--- a/mkdocs/api/neighbors.md
+++ b/mkdocs/api/neighbors.md
@@ -2,5 +2,5 @@
 
 :::sklego.neighbors.BayesianKernelDensityClassifier
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true

--- a/mkdocs/api/pandas-utils.md
+++ b/mkdocs/api/pandas-utils.md
@@ -2,15 +2,15 @@
 
 ::: sklego.pandas_utils.add_lags
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.pandas_utils.log_step
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.pandas_utils.log_step_extra
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true

--- a/mkdocs/api/pandas-utils.md
+++ b/mkdocs/api/pandas-utils.md
@@ -1,0 +1,16 @@
+# Pandas Utils
+
+::: sklego.pandas_utils.add_lags
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.pandas_utils.log_step
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.pandas_utils.log_step_extra
+    options:
+        show_root_full_path: false
+        show_root_heading: true

--- a/mkdocs/api/pipeline.md
+++ b/mkdocs/api/pipeline.md
@@ -4,15 +4,15 @@ Pipelines, variances to the sklearn.pipeline.Pipeline object.
 
 ::: sklego.pipeline.DebugPipeline
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.pipeline.make_debug_pipeline
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 ::: sklego.pipeline.default_log_callback
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true

--- a/mkdocs/api/pipeline.md
+++ b/mkdocs/api/pipeline.md
@@ -1,0 +1,18 @@
+# Pipeline
+
+Pipelines, variances to the sklearn.pipeline.Pipeline object.
+
+::: sklego.pipeline.DebugPipeline
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.pipeline.make_debug_pipeline
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+::: sklego.pipeline.default_log_callback
+    options:
+        show_root_full_path: false
+        show_root_heading: true

--- a/mkdocs/api/preprocessing.md
+++ b/mkdocs/api/preprocessing.md
@@ -2,65 +2,65 @@
 
 :::sklego.preprocessing.columncapper.ColumnCapper
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 :::sklego.preprocessing.pandastransformers.ColumnDropper
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 :::sklego.preprocessing.pandastransformers.ColumnSelector
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 :::sklego.preprocessing.dictmapper.DictMapper
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 :::sklego.preprocessing.identitytransformer.IdentityTransformer
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 :::sklego.preprocessing.projections.InformationFilter
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 :::sklego.preprocessing.intervalencoder.IntervalEncoder
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 :::sklego.preprocessing.projections.OrthogonalTransformer
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 :::sklego.preprocessing.outlier_remover.OutlierRemover
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 :::sklego.preprocessing.pandastransformers.PandasTypeSelector
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 :::sklego.preprocessing.patsytransformer.PatsyTransformer
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 :::sklego.preprocessing.randomadder.RandomAdder
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true
 
 :::sklego.preprocessing.repeatingbasis.RepeatingBasisFunction
     options:
-        show_root_full_path: false
+        show_root_full_path: true
         show_root_heading: true

--- a/mkdocs/api/preprocessing.md
+++ b/mkdocs/api/preprocessing.md
@@ -1,0 +1,66 @@
+# Preprocessing
+
+:::sklego.preprocessing.columncapper.ColumnCapper
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+:::sklego.preprocessing.pandastransformers.ColumnDropper
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+:::sklego.preprocessing.pandastransformers.ColumnSelector
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+:::sklego.preprocessing.dictmapper.DictMapper
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+:::sklego.preprocessing.identitytransformer.IdentityTransformer
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+:::sklego.preprocessing.projections.InformationFilter
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+:::sklego.preprocessing.intervalencoder.IntervalEncoder
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+:::sklego.preprocessing.projections.OrthogonalTransformer
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+:::sklego.preprocessing.outlier_remover.OutlierRemover
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+:::sklego.preprocessing.pandastransformers.PandasTypeSelector
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+:::sklego.preprocessing.patsytransformer.PatsyTransformer
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+:::sklego.preprocessing.randomadder.RandomAdder
+    options:
+        show_root_full_path: false
+        show_root_heading: true
+
+:::sklego.preprocessing.repeatingbasis.RepeatingBasisFunction
+    options:
+        show_root_full_path: false
+        show_root_heading: true

--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -1,0 +1,3 @@
+# scikit-lego
+
+Placeholder for the scikit-lego documentation.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ docs_packages = [
     "sphinx==4.5.0",
     "sphinx_rtd_theme==1.0.0",
     "nbsphinx==0.8.8",
-    "recommonmark==0.7.1"
+    "recommonmark==0.7.1",
+    "numpydoc",
 ]
 test_packages = all_packages + [  # we need extras packages for their tests
     "flake8>=3.6.0",

--- a/sklego/base.py
+++ b/sklego/base.py
@@ -2,27 +2,105 @@ from sklearn.base import OutlierMixin
 
 
 class ProbabilisticClassifierMeta(type):
+    """Metaclass for `ProbabilisticClassifier`.
+
+    This metaclass is responsible for checking whether a class can be considered a `ProbabilisticClassifier`.
+    A class is considered a `ProbabilisticClassifier` if it has a "predict_proba" method.
+    """
+
     def __instancecheck__(self, other):
+        """Checks if the provided object is a `ProbabilisticClassifier`.
+
+        Parameters
+        ----------
+        self : ProbabilisticClassifierMeta
+            `ProbabilisticClassifierMeta` class.
+        other : object
+            The object to check for `ProbabilisticClassifier` compatibility.
+
+        Returns
+        -------
+        bool
+            True if the object is a `ProbabilisticClassifier` (has a "predict_proba" method ), False otherwise.
+        """
         return hasattr(other, "predict_proba")
 
 
 class ProbabilisticClassifier(metaclass=ProbabilisticClassifierMeta):
+    """Base class for `ProbabilisticClassifier`.
+
+    This base class defines the `ProbabilisticClassifier` interface, indicating that subclasses should have a
+    "predict_proba" method.
+    """
+
     pass
 
 
 class ClustererMeta(type):
+    """Metaclass for `Clusterer`.
+
+    This metaclass is responsible for checking whether a class can be considered a `Clusterer`.
+    A class is considered a `Clusterer` if it has a "fit_predict" method.
+    """
+
     def __instancecheck__(self, other):
+        """Checks if the provided object is a `Clusterer`.
+
+        Parameters
+        ----------
+        self : ClustererMeta
+            `ClustererMeta` class.
+        other : object
+            The object to check for `Clusterer` compatibility.
+
+        Returns
+        -------
+        bool
+            True if the object is a `Clusterer` (has a "fit_predict" method ), False otherwise.
+        """
         return hasattr(other, "fit_predict")
 
 
 class Clusterer(metaclass=ClustererMeta):
+    """Base class for `Clusterer`.
+
+    This base class defines the `Clusterer` interface, indicating that subclasses should have a "fit_predict" method.
+    """
+
     pass
 
 
 class OutlierModelMeta(type):
+    """Metaclass for `OutlierModel`.
+
+    This metaclass is responsible for checking whether a class can be considered an `OutlierModel`.
+    A class is considered an `OutlierModel` if it is an instance of the `sklearn.base.OutlierMixin` class.
+    """
+
     def __instancecheck__(self, other):
+        """
+        Check if the provided object is an `OutlierModel`.
+
+        Parameters
+        ----------
+        self : OutlierModelMeta
+            The `OutlierModelMeta` class.
+        other : object
+            The object to check for `OutlierModel` compatibility.
+
+        Returns
+        -------
+        bool
+            True if the object is an `OutlierModel` (an instance of "OutlierMixin"), False otherwise.
+        """
         return isinstance(other, OutlierMixin)
 
 
 class OutlierModel(metaclass=OutlierModelMeta):
+    """Base class for `OutlierModel`.
+
+    This base class defines the `OutlierModel` interface, indicating that subclasses should be instances of the
+    "OutlierMixin" class.
+    """
+
     pass

--- a/sklego/common.py
+++ b/sklego/common.py
@@ -8,46 +8,73 @@ from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
 
 
 class TrainOnlyTransformerMixin(TransformerMixin):
-    """
-    Allows using a separate function for transforming train and test data
+    """Mixin class for transformers that can handle training and test data differently.
 
-    Usage:
-        >>> from sklearn.base import BaseEstimator
-        >>> class TrainOnlyTransformer(TrainOnlyTransformerMixin, BaseEstimator):
-        ...     def fit(self, X, y):
-        ...         super().fit(X, y)
-        ...
-        ...     def transform_train(self, X, y=None):
-        ...          return X + np.random.normal(0, 1, size=X.shape)
-        ...
-        >>> X_train, X_test = np.random.randn(100, 4), np.random.randn(100, 4)
-        >>> y_train, y_test = np.random.randn(100), np.random.randn(100)
-        >>>
-        >>> trf = TrainOnlyTransformer()
-        >>> trf.fit(X_train, y_train)
-        >>>
-        >>> assert np.all(trf.transform(X_train) != X_train)
-        >>> assert np.all(trf.transform(X_test) == X_test)
+    This mixin allows using a separate function for transforming training and test data.
 
-    .. warning:: Transformers using this class as a mixin should at a minimum:
+    !!! warning
 
-        - call `super().fit` in their fit method
-        - implement `transform_train()`
+        Transformers using this class as a mixin should:
 
-        They may also implement `transform_test()`. If it is not implemented,
-        `transform_test` will simply return the untransformed dataframe
+        - Call `super().fit` in their fit method.
+        - Implement `transform_train()` method.
+
+        They may also implement `transform_test()` method, if not implemented, `transform_test()` will simply return
+        the untransformed data.
+
+    Attributes
+    ----------
+    X_hash_ : hash
+        The hash of the training data - used to determine whether to use `transform_train` or `transform_test`.
+    dim_ : int
+        The number of dimension seen furing `.fit()` in the training data.
+
+    Examples
+    --------
+    ```py
+    from sklearn.base import BaseEstimator
+    from sklego.common import TrainOnlyTransformerMixin
+
+    class TrainOnlyTransformer(TrainOnlyTransformerMixin, BaseEstimator):
+        def fit(self, X, y):
+            super().fit(X, y)
+
+        def transform_train(self, X, y=None):
+            '''Add random noise to the training data.'''
+            return X + np.random.normal(0, 1, size=X.shape)
+
+    X_train, X_test = np.random.randn(100, 4), np.random.randn(100, 4)
+    y_train, y_test = np.random.randn(100), np.random.randn(100)
+
+    trf = TrainOnlyTransformer()
+    trf.fit(X_train, y_train)
+
+    assert np.all(trf.transform(X_train) != X_train)
+    assert np.all(trf.transform(X_test) == X_test)
+    ```
     """
 
     _HASHERS = {
-        pd.DataFrame: lambda X: hashlib.sha256(
-            pd.util.hash_pandas_object(X, index=True).values
-        ).hexdigest(),
+        pd.DataFrame: lambda X: hashlib.sha256(pd.util.hash_pandas_object(X, index=True).values).hexdigest(),
         np.ndarray: lambda X: hash(X.data.tobytes()),
         np.memmap: lambda X: hash(X.data.tobytes()),
     }
 
     def fit(self, X, y=None):
-        """Calculates the hash of X_train"""
+        """Fit the mixin by calculating the hash of `X` and stores it in `self.X_hash_`.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features )
+            The training data.
+        y : array-like of shape (n_samples,) | None, default=None
+            The target values.
+
+        Returns
+        -------
+        self : TrainOnlyTransformerMixin
+            The fitted transformer.
+        """
         if y is None:
             check_array(X, estimator=self)
         else:
@@ -58,31 +85,67 @@ class TrainOnlyTransformerMixin(TransformerMixin):
 
     @staticmethod
     def _hash(X):
-        """Returns a hash of X based on the type of X. Hashers are defined in TrainOnlyMixin.HASHERS"""
+        """Calculate a hash of X based on its type. Hashers are defined in TrainOnlyMixin.HASHERS.
+
+        Supported types are:
+
+            - pd.DataFrame
+            - np.ndarray
+            - np.memmap
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to hash.
+
+        Returns
+        -------
+        hash
+            The calculated hash value.
+
+        Raises
+        ------
+        ValueError
+            If the type of `X` is not supported.
+        """
         try:
             hasher = TrainOnlyTransformerMixin._HASHERS[type(X)]
         except KeyError:
             raise ValueError(
                 f"Unknown datatype {type(X)}, "
-                f"TransformerSelector only supports {TrainOnlyTransformerMixin.HASHERS.keys()}"
+                f"`TrainOnlyTransformerMixin` only supports {TrainOnlyTransformerMixin.HASHERS.keys()}"
             )
         else:
             return hasher(X)
 
     def transform(self, X, y=None):
-        """
-        Dispatcher for transform method.
+        """Dispatch to `transform_train()` or `transform_test()` based on the data passed.
 
-        It will dispatch to `self.transform_train` if X is the same as X passed to `fit`, otherwise, it will dispatch
-        to `self.trainsform_test`
+        This method will check whether the hash of `X` matches the hash of the training data. If it does, it will
+        dispatch to `transform_train()`, otherwise it will dispatch to `transform_test()`.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to transform.
+        y : array-like of shape (n_samples,) or None, default=None.
+            The target values.
+
+        Returns
+        -------
+        array-like of shape (n_samples, n_features)
+            The transformed data.
+
+        Raises
+        ------
+        ValueError
+            If the input dimension does not match the training dimension.
         """
         check_is_fitted(self, ["X_hash_", "dim_"])
         check_array(X, estimator=self)
 
         if X.shape[1] != self.dim_:
-            raise ValueError(
-                f"Unexpected input dimension {X.shape[1]}, expected {self.dim_}"
-            )
+            raise ValueError(f"Unexpected input dimension {X.shape[1]}, expected {self.dim_}")
 
         if self._hash(X) == self.X_hash_:
             return self.transform_train(X)
@@ -90,28 +153,72 @@ class TrainOnlyTransformerMixin(TransformerMixin):
             return self.transform_test(X)
 
     def transform_train(self, X, y=None):
-        raise NotImplementedError(
-            "Subclasses of TrainOnlyMixin should implement `transform_train`"
-        )
+        """Transform the training data.
+
+        This method should be implemented in subclasses to specify how training data should be transformed.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features )
+            The training data.
+        y : array-like of shape (n_samples,) or None, default=None
+            The target values.
+
+        Returns
+        -------
+        array-like of shape (n_samples, n_features)
+            The transformed training data.
+        """
+        raise NotImplementedError("Subclasses of `TrainOnlyTransformerMixin` should implement `transform_train` method")
 
     def transform_test(self, X, y=None):
+        """Transform the test data.
+
+        This method can be implemented in subclasses to specify how test data should be transformed.
+        If not implemented, it will return the untransformed data.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The test data.
+        y : array-like of shape (n_samples,) or None, default=None
+            The target values.
+
+        Returns
+        -------
+        array-like of shape (n_samples, n_features)
+            The transformed test data or untransformed data if not implemented.
+        """
         return X
 
 
 def as_list(val):
-    """
-    Helper function, always returns a list of the input value.
+    """Ensure the input value is converted into a list.
 
-    :param val: the input value.
-    :returns: the input value as a list.
+    This helper function takes an input value and ensures that it is always returned as a list.
 
-    :Example:
+    - If the input is a single value, it will be wrapped in a list.
+    - If the input is an iterable, it will be converted into a list.
 
-    >>> as_list('test')
-    ['test']
+    Parameters
+    ----------
+    val : object
+        The input value that needs to be converted into a list.
 
-    >>> as_list(['test1', 'test2'])
-    ['test1', 'test2']
+    Returns
+    -------
+    list
+        The input value as a list.
+
+    Examples
+    --------
+    ```py
+    as_list("test")
+    # ['test']
+
+    as_list(["test1", "test2"])
+    # ['test1', 'test2']
+    ```
     """
     treat_single_value = str
 
@@ -125,68 +232,99 @@ def as_list(val):
 
 
 def flatten(nested_iterable):
-    """
-    Helper function, returns an iterator of flattened values from an arbitrarily nested iterable
+    """Recursively flatten an arbitrarily nested iterable into an iterator of values.
 
-    >>> list(flatten([['test1', 'test2'], ['a', 'b', ['c', 'd']]]))
-    ['test1', 'test2', 'a', 'b', 'c', 'd']
+    This helper function takes an arbitrarily nested iterable and returns an iterator of flattened values.
+    It recursively processes the input to extract individual elements and yield them in a flat structure.
 
-    >>> list(flatten(['test1', ['test2']]))
-    ['test1', 'test2']
+    Parameters
+    ----------
+    nested_iterable : Iterable
+        An arbitrarily nested iterable to be flattened.
+
+    Yields
+    ------
+    Generator
+        A generator of flattened values from the nested iterable.
+
+    Examples
+    --------
+    ```py
+    list(flatten([["test1", "test2"], ["a", "b", ["c", "d"]]))
+    # ['test1', 'test2', 'a', 'b', 'c', 'd']
+
+    list(flatten(["test1", ["test2"]])
+    # ['test1', 'test2']
+    ```
     """
     for el in nested_iterable:
-        if isinstance(el, collections.abc.Iterable) and not isinstance(
-            el, (str, bytes)
-        ):
+        if isinstance(el, collections.abc.Iterable) and not isinstance(el, (str, bytes)):
             yield from flatten(el)
         else:
             yield el
 
 
 def expanding_list(list_to_extent, return_type=list):
-    """
-    Make a expanding list of lists by making tuples of the first element, the first 2 elements etc.
+    """Create an expanding list of lists or tuples by making combinations of elements.
 
-    :param list_to_extent:
-    :param return_type: type of the elements of the list (tuple or list)
+    This function takes an input list and creates an expanding list, where each element is a list or tuple containing a
+    subset of elements from the input list. The resulting list can be composed of lists or tuples, depending on the
+    specified `return_type`.
 
-    :Example:
+    Parameters
+    ----------
+    list_to_extent : object
+        The input to be extended.
+    return_type : type, default=list
+        The type of elements in the resulting list (list or tuple).
 
-    >>> expanding_list('test')
-    [['test']]
+    Returns
+    -------
+    list
+        An expanding list of `list`s or `tuple`s containing combinations of elements from the input.
 
-    >>> expanding_list(['test1', 'test2', 'test3'])
-    [['test1'], ['test1', 'test2'], ['test1', 'test2', 'test3']]
+    Examples
+    --------
+    ```py
+    expanding_list("test")
+    # [['test']]
 
-    >>> expanding_list(['test1', 'test2', 'test3'], tuple)
-    [('test1',), ('test1', 'test2'), ('test1', 'test2', 'test3')]
+    expanding_list(["test1", "test2", "test3"])
+    # [['test1'], ['test1', 'test2'], ['test1', 'test2', 'test3']]
+
+    expanding_list(["test1", "test2", "test3"], tuple)
+    # [('test1',), ('test1', 'test2'), ('test1', 'test2', 'test3')]
+    ```
     """
     listed = as_list(list_to_extent)
-    if len(listed) <= 1:
-        return [listed]
-
     return [return_type(listed[: n + 1]) for n in range(len(listed))]
 
 
 def sliding_window(sequence, window_size, step_size):
-    """Returns sliding window generator object from a sequence
+    """Generate sliding windows over a sequence.
 
-    :param sequence: e.g. a list
-    :type sequence: Iterable
-    :param window_size: the size of each window
-    :type window_size: int
-    :param step_size: the amount of steps to the next window
-    :type step_size: int
-    :return: a sliding window generator object
-    :rtype: Generator
+    This function generates sliding windows of a specified size over a given sequence, where each window is a list of
+    elements from the sequence.
 
-    :Example:
+    Parameters
+    ----------
+    sequence : Iterable
+        The input sequence (e.g., a list).
+    window_size : int
+        The size of each sliding window.
+    step_size : int
+        The amount of steps to the next window.
 
-    >>> generator = sliding_window([1,2,4,5], 2, 1)
-    >>> [i for i in generator]
-    [[1,2], [2,4], [4,5], [5]]
+    Returns
+    -------
+    Generator
+        A generator object that yields sliding windows.
+
+    Examples
+    --------
+    ```
+    list(sliding_window([1, 2, 4, 5], 2, 1))
+    # [[1, 2], [2, 4], [4, 5], [5]]
+    ```
     """
-    return (
-        sequence[pos : pos + window_size]
-        for pos in range(0, len(sequence), step_size)
-    )
+    return (sequence[pos : pos + window_size] for pos in range(0, len(sequence), step_size))

--- a/sklego/datasets.py
+++ b/sklego/datasets.py
@@ -1,92 +1,95 @@
 import os
+
 import numpy as np
 import pandas as pd
 from pkg_resources import resource_filename
-
 from sklearn.datasets import fetch_openml
 
 
 def load_penguins(return_X_y=False, as_frame=False):
-    """
-    Loads the penguins dataset, which is a lovely alternative for the iris dataset. We've
-    added this dataset for educational use.
+    """Loads the penguins dataset, which is a lovely alternative for the iris dataset.
+    We've added this dataset for educational use.
 
-    Data were collected and made available by Dr. Kristen Gorman and the Palmer Station,
-    Antarctica LTER, a member of the Long Term Ecological Research Network. The goal
-    of the dataset is to predict which species of penguin a penguin belongs to.
+    Data were collected and made available by Dr. Kristen Gorman and the Palmer Station, Antarctica LTER, a member of
+    the Long Term Ecological Research Network. The goal of the dataset is to predict which species of penguin a penguin
+    belongs to.
 
-    This data originally appeared as a R package and R users can find this data
-    in the palmerpenguins package https://github.com/allisonhorst/palmerpenguins.
+    This data originally appeared as a R package and R users can find this data in the
+    [palmerpenguins package](https://github.com/allisonhorst/palmerpenguins).
     You can also go to the repository for some lovely images that explain the dataset.
 
     To cite this dataset in publications use:
 
-    Gorman KB, Williams TD, Fraser WR (2014) Ecological Sexual Dimorphism
-    and Environmental Variability within a Community of Antarctic
-    Penguins (Genus Pygoscelis). PLoS ONE 9(3): e90081.
-    https://doi.org/10.1371/journal.pone.0090081
+        Gorman KB, Williams TD, Fraser WR (2014) Ecological Sexual Dimorphism
+        and Environmental Variability within a Community of Antarctic
+        Penguins (Genus Pygoscelis). PLoS ONE 9(3): e90081.
+        https://doi.org/10.1371/journal.pone.0090081
 
-    :param return_X_y: If True, returns ``(data, target)`` instead of a dict object.
-    :param as_frame: give the pandas dataframe instead of X, y matrices (default=False)
+    Parameters
+    ----------
+    return_X_y : bool, default=False
+        If True, returns `(data, target)` instead of a dict object.
+    as_frame : bool, default=False
+        If True, returns `data` as a pandas DataFrame  instead of X, y matrices.
 
-    :Example:
-    >>> from sklego.datasets import load_penguins
-    >>> X, y = load_penguins(return_X_y=True)
-    >>> X.shape
-    (344, 6)
-    >>> y.shape
-    (344,)
-    >>> load_penguins(as_frame=True).columns
-    Index(['species', 'island', 'bill_length_mm', 'bill_depth_mm',
-           'flipper_length_mm', 'body_mass_g', 'sex'],
-          dtype='object')
+    Examples
+    -------
+    ```py
+    from sklego.datasets import load_penguins
+    X, y = load_penguins(return_X_y=True)
 
-    Additional data use information
-    ###############################
+    X.shape
+    # (344, 6)
+    y.shape
+    # (344,)
 
+    load_penguins(as_frame=True).columns
+    # Index(['species', 'island', 'bill_length_mm', 'bill_depth_mm',
+    #    'flipper_length_mm', 'body_mass_g', 'sex'],
+    #   dtype='object')
+    ```
+
+    Notes
+    -----
     Anyone interested in publishing the data should contact
-    `Dr. Kristen Gorman <https://www.uaf.edu/cfos/people/faculty/detail/kristen-gorman.php>`_
+    [`Dr. Kristen Gorman`](https://www.uaf.edu/cfos/people/faculty/detail/kristen-gorman.php)
     about analysis and working together on any final products.
 
-    From Gorman et al. (2014):
+    !!! quote "From Gorman et al. (2014)"
 
-    > “Data reported here are publicly available within the PAL-LTER data
-    > system (datasets 219, 220, and 221):
-    > `<http://oceaninformatics.ucsd.edu/datazoo/data/pallter/datasets>`_.
-    > Individuals interested in using these data are therefore expected to
-    > follow the US LTER Network’s Data Access Policy, Requirements and Use
-    > Agreement: `<https://lternet.edu/data-access-policy/>`_.”
+        Data reported here are publicly available within the
+        [PAL-LTER data system (datasets 219, 220, and 221)](http://oceaninformatics.ucsd.edu/datazoo/data/pallter/datasets).
 
-    **Please cite data using the following:**
+        Individuals interested in using these data are therefore expected to follow the [US LTER Network's Data Access
+        Policy, Requirements and Use Agreement](https://lternet.edu/data-access-policy/)
 
+    Please cite data using the following
+    ------------------------------------
     **Adélie penguins:**
 
-      - Palmer Station Antarctica LTER and K. Gorman, 2020. Structural size
-        measurements and isotopic signatures of foraging among adult male
-        and female Adélie penguins (*Pygoscelis adeliae*) nesting along the
-        Palmer Archipelago near Palmer Station, 2007-2009 ver 5.
-        Environmental Data Initiative.
-        `<https://doi.org/10.6073/pasta/98b16d7d563f265cb52372c8ca99e60f>`_
+      - [Palmer Station Antarctica LTER and K. Gorman, 2020. Structural size measurements and isotopic signatures of
+        foraging among adult male and female Adélie penguins (*Pygoscelis adeliae*) nesting along the Palmer Archipelago
+        near Palmer Station, 2007-2009 ver 5. Environmental Data
+        Initiative](https://doi.org/10.6073/pasta/98b16d7d563f265cb52372c8ca99e60f).
+
         (Accessed 2020-06-08).
 
     **Gentoo penguins:**
 
-      - Palmer Station Antarctica LTER and K. Gorman, 2020. Structural size
-        measurements and isotopic signatures of foraging among adult male
-        and female Gentoo penguin (*Pygoscelis papua*) nesting along the
-        Palmer Archipelago near Palmer Station, 2007-2009 ver 5.
-        Environmental Data Initiative.
-        `<https://doi.org/10.6073/pasta/7fca67fb28d56ee2ffa3d9370ebda689>`_
+      - [Palmer Station Antarctica LTER and K. Gorman, 2020. Structural size measurements and isotopic signatures of
+        foraging among adult male and female Gentoo penguin (*Pygoscelis papua*) nesting along the Palmer Archipelago
+        near Palmer Station, 2007-2009 ver 5. Environmental Data
+        Initiative](https://doi.org/10.6073/pasta/7fca67fb28d56ee2ffa3d9370ebda689).
+
         (Accessed 2020-06-08).
 
     **Chinstrap penguins:**
 
-      - Palmer Station Antarctica LTER and K. Gorman, 2020. Structural size
-        measurements and isotopic signatures of foraging among adult male
-        and female Chinstrap penguin (*Pygoscelis antarcticus*) nesting
-        along the Palmer Archipelago near Palmer Station, 2007-2009 ver 6.
-        Environmental Data Initiative.
-        `<https://doi.org/10.6073/pasta/c14dfcfada8ea13a17536e73eb6fbe9e>`_
+      - [Palmer Station Antarctica LTER and K. Gorman, 2020. Structural size measurements and isotopic signatures of
+        foraging among adult male and female Chinstrap penguin (*Pygoscelis antarcticus*) nesting along the Palmer
+        Archipelago near Palmer Station, 2007-2009 ver 6.
+        Environmental Data Initiative](https://doi.org/10.6073/pasta/c14dfcfada8ea13a17536e73eb6fbe9e).
+
         (Accessed 2020-06-08).
     """
     filepath = resource_filename("sklego", os.path.join("data", "penguins.zip"))
@@ -112,33 +115,41 @@ def load_penguins(return_X_y=False, as_frame=False):
 
 
 def load_arrests(return_X_y=False, as_frame=False):
-    """
-    Loads the arrests dataset which can serve as a benchmark for fairness. It is data on
-    the police treatment of individuals arrested in Toronto for simple possession of small
-    quantities of marijuana. The goal is to predict whether or not the arrestee was released
-    with a summons while maintaining a degree of fairness.
+    """Loads the arrests dataset which can serve as a benchmark for fairness.
 
-    :param return_X_y: If True, returns ``(data, target)`` instead of a dict object.
-    :param as_frame: give the pandas dataframe instead of X, y matrices (default=False)
+    It is data on the police treatment of individuals arrested in Toronto for simple possession of small quantities of
+    marijuana. The goal is to predict whether or not the arrestee was released with a summons while maintaining a
+    degree of fairness.
 
-    :Example:
-    >>> from sklego.datasets import load_arrests
-    >>> X, y = load_arrests(return_X_y=True)
-    >>> X.shape
-    (5226, 7)
-    >>> y.shape
-    (5226,)
-    >>> load_arrests(as_frame=True).columns
-    Index(['released', 'colour', 'year', 'age', 'sex', 'employed', 'citizen',
-           'checks'],
-          dtype='object')
+    Parameters
+    ----------
+    return_X_y : bool, default=False
+        If True, returns `(data, target)` instead of a dict object.
+    as_frame : bool, default=False
+        If True, returns `data` as a pandas DataFrame  instead of X, y matrices.
 
-    The dataset was copied from the carData R package and can originally be found in:
+    Examples
+    -------
+    ```py
+    from sklego.datasets import load_arrests
+    X, y = load_arrests(return_X_y=True)
+
+    X.shape
+    # (5226, 7)
+    y.shape
+    # (5226,)
+
+    load_arrests(as_frame=True).columns
+    # Index(['released', 'colour', 'year', 'age', 'sex', 'employed', 'citizen',
+    #   'checks'],
+    #  dtype='object')
+    ```
+
+    The dataset was copied from the carData R package
+    ([dataset documentation](http://vincentarelbundock.github.io/Rdatasets/doc/carData/Arrests.html))
+    and can originally be found in:
 
     - Personal communication from Michael Friendly, York University.
-
-    The documentation page of the dataset from the package can be viewed here:
-    http://vincentarelbundock.github.io/Rdatasets/doc/carData/Arrests.html
     """
     filepath = resource_filename("sklego", os.path.join("data", "arrests.zip"))
     df = pd.read_csv(filepath)
@@ -154,26 +165,33 @@ def load_arrests(return_X_y=False, as_frame=False):
 
 
 def load_chicken(return_X_y=False, as_frame=False):
-    """
-    Loads the chicken dataset. The chicken data has 578 rows and 4 columns
-    from an experiment on the effect of diet on early growth of chicks.
-    The body weights of the chicks were measured at birth and every second
-    day thereafter until day 20. They were also measured on day 21.
-    There were four groups on chicks on different protein diets.
+    """Loads the chicken dataset.
 
-    :param return_X_y: If True, returns ``(data, target)`` instead of a dict object.
-    :param as_frame: give the pandas dataframe instead of X, y matrices (default=False)
+    The chicken data has 578 rows and 4 columns from an experiment on the effect of diet on early growth of chicks.
+    The body weights of the chicks were measured at birth and every second day thereafter until day 20.
+    They were also measured on day 21. There were four groups on chicks on different protein diets.
 
-    :Example:
+    Parameters
+    ----------
+    return_X_y : bool, default=False
+        If True, returns `(data, target)` instead of a dict object.
+    as_frame : bool, default=False
+        If True, returns `data` as a pandas DataFrame  instead of X, y matrices.
 
-    >>> from sklego.datasets import load_chicken
-    >>> X, y = load_chicken(return_X_y=True)
-    >>> X.shape
-    (578, 3)
-    >>> y.shape
-    (578,)
-    >>> load_chicken(as_frame=True).columns
-    Index(['weight', 'time', 'chick', 'diet'], dtype='object')
+    Examples
+    -------
+    ```py
+    from sklego.datasets import load_chicken
+    X, y = load_chicken(return_X_y=True)
+
+    X.shape
+    # (578, 3)
+    y.shape
+    # (578,)
+
+    load_chicken(as_frame=True).columns
+    # Index(['weight', 'time', 'chick', 'diet'], dtype='object')
+    ```
 
     The datasets can be found in the following sources:
 
@@ -194,27 +212,37 @@ def load_abalone(return_X_y=False, as_frame=False):
     """
     Loads the abalone dataset where the goal is to predict the gender of the creature.
 
-    :param return_X_y: If True, returns ``(data, target)`` instead of a dict object.
-    :param as_frame: give the pandas dataframe instead of X, y matrices (default=False)
+    Parameters
+    ----------
+    return_X_y : bool, default=False
+        If True, returns `(data, target)` instead of a dict object.
+    as_frame : bool, default=False
+        If True, returns `data` as a pandas DataFrame  instead of X, y matrices.
 
-    :Example:
+    Examples
+    ---------
+    ```py
+    from sklego.datasets import load_abalone
+    X, y = load_abalone(return_X_y=True)
 
-    >>> from sklego.datasets import load_abalone
-    >>> X, y = load_abalone(return_X_y=True)
-    >>> X.shape
-    (4177, 8)
-    >>> y.shape
-    (4177,)
-    >>> load_abalone(as_frame=True).columns
-    Index(['sex', 'length', 'diameter', 'height', 'whole_weight', 'shucked_weight',
-           'viscera_weight', 'shell_weight', 'rings'],
-          dtype='object')
+    X.shape
+    # (4177, 8)
+    y.shape
+    # (4177,)
 
-    The dataset was copied from Kaggle and can originally be found in: can be found in the following sources:
+    load_abalone(as_frame=True).columns
+    # Index(['sex', 'length', 'diameter', 'height', 'whole_weight', 'shucked_weight',
+    #        'viscera_weight', 'shell_weight', 'rings'],
+    #       dtype='object')
+    ```
+
+    The dataset was copied from Kaggle and can originally be found in the following sources:
 
     - Warwick J Nash, Tracy L Sellers, Simon R Talbot, Andrew J Cawthorn and Wes B Ford (1994)
-    "The Population Biology of Abalone (_Haliotis_ species) in Tasmania."
-    Sea Fisheries Division, Technical Report No. 48 (ISSN 1034-3288)
+
+        "The Population Biology of Abalone (_Haliotis_ species) in Tasmania."
+
+        Sea Fisheries Division, Technical Report No. 48 (ISSN 1034-3288)
     """
     filepath = resource_filename("sklego", os.path.join("data", "abalone.zip"))
     df = pd.read_csv(filepath)
@@ -239,22 +267,32 @@ def load_abalone(return_X_y=False, as_frame=False):
 
 
 def load_heroes(return_X_y=False, as_frame=False):
-    """
-    A dataset from a video game: "heroes of the storm". The goal of the dataset
-    is to predict the attack type. Note that the pandas dataset returns more information.
-    This is because we wanted to keep the X simple in the return_X_y case.
-    :param return_X_y: If True, returns ``(data, target)`` instead of a dict object.
-    :param as_frame: give the pandas dataframe instead of X, y matrices (default=False)
+    """A dataset from the video game [Heroes of the storm](https://heroesofthestorm.blizzard.com/en-us/).
 
-    :Example:
-    >>> X, y = load_heroes(return_X_y=True)
-    >>> X.shape
-    (84, 2)
-    >>> y.shape
-    (84,)
-    >>> df = load_heroes(as_frame=True)
-    >>> df.columns
-    Index(['name', 'attack_type', 'role', 'health', 'attack', 'attack_spd'], dtype='object')
+    The goal of the dataset is to predict the attack type. Note that the pandas dataset returns more information.
+    This is because we wanted to keep the X simple in the return_X_y case.
+
+    Parameters
+    ----------
+    return_X_y : bool, default=False
+        If True, returns `(data, target)` instead of a dict object.
+    as_frame : bool, default=False
+        If True, returns `data` as a pandas DataFrame  instead of X, y matrices.
+
+    Examples
+    --------
+    ```py
+    from sklego.datasets import load_heroes
+    X, y = load_heroes(return_X_y=True)
+
+    X.shape
+    # (84, 2)
+    y.shape
+    # (84,)
+
+    load_heroes(as_frame=True).columns
+    # Index(['name', 'attack_type', 'role', 'health', 'attack', 'attack_spd'], dtype='object')
+    ```
     """
     filepath = resource_filename("sklego", os.path.join("data", "heroes.zip"))
     df = pd.read_csv(filepath)
@@ -267,64 +305,8 @@ def load_heroes(return_X_y=False, as_frame=False):
     return {"data": X, "target": y}
 
 
-def make_simpleseries(
-    n_samples=365 * 5,
-    trend=0.001,
-    season_trend=0.001,
-    noise=0.5,
-    as_frame=False,
-    seed=None,
-    stack_noise=False,
-    start_date=None,
-):
-    """
-    Generate a very simple timeseries dataset to play with. The generator
-    returns a daily time-series with a yearly seasonality, trend, and noise.
-
-    :param n_samples: The number of days to simulate the timeseries for.
-    :param trend: The long term trend in the dataset.
-    :param season_trend: The long term trend in the seasonality.
-    :param noise: The noise that is applied to the dataset.
-    :param as_frame: Return a pandas dataframe instead of a numpy array.
-    :param seed: The seed value for the randomness.
-    :param stack_noise: Set the noise to be stacked by a cumulative sum.
-    :param start_date: Also add a start date (only works if `as_frame`=True).
-    :return: numpy array unless dataframe is specified
-
-    :Example:
-
-    >>> from sklego.datasets import make_simpleseries
-    >>> make_simpleseries(seed=42)
-    array([-0.34078806, -0.61828731, -0.18458236, ..., -0.27547402,
-           -0.38237413,  0.13489355])
-    >>> make_simpleseries(as_frame=True, start_date="2018-01-01", seed=42).head(3)
-             yt       date
-    0 -0.340788 2018-01-01
-    1 -0.618287 2018-01-02
-    2 -0.184582 2018-01-03
-    """
-    if seed:
-        np.random.seed(seed)
-    time = np.arange(0, n_samples)
-    noise = np.random.normal(0, noise, n_samples)
-    if stack_noise:
-        noise = noise.cumsum()
-    r1, r2 = np.random.normal(0, 1, 2)
-    seasonality = r1 * np.sin(time / 365 * 2 * np.pi) + r2 * np.cos(
-        time / 365 * 4 * np.pi + 1
-    )
-    result = seasonality + season_trend * seasonality * time + trend * time + noise
-    if as_frame:
-        if start_date:
-            stamps = pd.date_range(start_date, periods=n_samples)
-            return pd.DataFrame({"yt": result, "date": stamps})
-        return pd.DataFrame({"yt": result})
-    return result
-
-
 def load_hearts(return_X_y=False, as_frame=False):
-    """
-    Loads the Cleveland Heart Diseases dataset.
+    """Loads the Cleveland Heart Diseases dataset.
 
     The goal is to predict the presence of a heart disease (target values 1, 2, 3, and 4).
     The data originates from research to heart diseases by four institutions and originally contains 76 attributes.
@@ -332,23 +314,32 @@ def load_hearts(return_X_y=False, as_frame=False):
     This implementation loads the Cleveland dataset of the research which is the only set used by ML researchers
     to this date.
 
-    :param return_X_y: If True, returns ``(data, target)`` instead of a dict object.
-    :param as_frame: give the pandas dataframe instead of X, y matrices (default=False)
+    Parameters
+    ----------
+    return_X_y : bool, default=False
+        If True, returns `(data, target)` instead of a dict object.
+    as_frame : bool, default=False
+        If True, returns `data` as a pandas DataFrame  instead of X, y matrices.
 
-    :Example:
-    >>> X, y = load_hearts(return_X_y=True)
-    >>> X.shape
-    (303, 13)
-    >>> y.shape
-    (303,)
-    >>> df = load_hearts(as_frame=True)
-    >>> df.columns
-    Index(['age', 'sex', 'cp', 'trestbps', 'chol', 'fbs', 'restecg', 'thalach',
-           'exang', 'oldpeak', 'slope', 'ca', 'thal', 'target'],
-          dtype='object')
+    Examples
+    --------
+    ```py
+    from sklego.datasets import load_hearts
+    X, y = load_hearts(return_X_y=True)
 
-    The dataset can originally be found here:
-    https://archive.ics.uci.edu/ml/datasets/Heart+Disease
+    X.shape
+    # (303, 13)
+    y.shape
+    # (303,)
+
+    load_hearts(as_frame=True).columns
+    # Index(['age', 'sex', 'cp', 'trestbps', 'chol', 'fbs', 'restecg', 'thalach',
+    #        'exang', 'oldpeak', 'slope', 'ca', 'thal', 'target'],
+    #       dtype='object')
+    ```
+
+    The dataset can originally be found in the
+    [UC Irvine Machine Learning Repository](https://archive.ics.uci.edu/ml/datasets/Heart+Disease)
 
     The responsible institutions for the entire database are:
 
@@ -357,7 +348,7 @@ def load_hearts(return_X_y=False, as_frame=False):
     3. University Hospital, Basel, Switzerland: Matthias Pfisterer, M.D.
     4. V.A. Medical Center, Long Beach and Cleveland Clinic Foundation: Robert Detrano, M.D., Ph.D.
 
-    The documentation of the dataset can be viewed here:
+    The documentation of the dataset can be viewed at:
     https://archive.ics.uci.edu/ml/machine-learning-databases/heart-disease/heart-disease.names
     """
     filepath = resource_filename("sklego", os.path.join("data", "hearts.zip"))
@@ -387,55 +378,122 @@ def load_hearts(return_X_y=False, as_frame=False):
     return {"data": X, "target": y}
 
 
-def fetch_creditcard(*, cache=True, data_home=None, as_frame=False, return_X_y=False):
+def make_simpleseries(
+    n_samples=365 * 5,
+    trend=0.001,
+    season_trend=0.001,
+    noise=0.5,
+    as_frame=False,
+    seed=None,
+    stack_noise=False,
+    start_date=None,
+):
+    """Generate a very simple timeseries dataset to play with.
+
+    The generator returns a daily time-series with a yearly seasonality, trend, and noise.
+
+    Parameters
+    ----------
+    n_samples : int, default=365 * 5
+        The number of days to simulate the timeseries for.
+    trend : float, default=0.001
+        The long term trend in the dataset.
+    season_trend : float, default=0.001
+        The long term trend in the seasonality.
+    noise : float, default=0.5
+        The noise that is applied to the dataset.
+    as_frame : bool, default=False
+        Whether to return a pandas dataframe instead of a numpy array.
+    seed : int | None, default=None
+        The seed value for the randomness.
+    stack_noise : bool, default=False
+        Set the noise to be stacked by a cumulative sum.
+    start_date : str | None, default=None
+        Also add a start date (only works if `as_frame`=True).
+
+    Returns
+    -------
+    np.ndarray | pd.DataFrame
+        Timeseries dataset with specified characteristics.
+
+    Examples
+    --------
+    ```py
+    from sklego.datasets import make_simpleseries
+
+    make_simpleseries(seed=42)
+    # array([-0.34078806, -0.61828731, -0.18458236, ..., -0.27547402,
+    #        -0.38237413,  0.13489355])
+
+    make_simpleseries(as_frame=True, start_date="2018-01-01", seed=42).head(3)
+    '''
+             yt       date
+    0 -0.340788 2018-01-01
+    1 -0.618287 2018-01-02
+    2 -0.184582 2018-01-03
+    '''
+    ```
     """
-    Load the creditcard dataset. Download it if necessary.
+    if seed:
+        np.random.seed(seed)
+    time = np.arange(0, n_samples)
+    noise = np.random.normal(0, noise, n_samples)
+    if stack_noise:
+        noise = noise.cumsum()
+    r1, r2 = np.random.normal(0, 1, 2)
+    seasonality = r1 * np.sin(time / 365 * 2 * np.pi) + r2 * np.cos(time / 365 * 4 * np.pi + 1)
+    result = seasonality + season_trend * seasonality * time + trend * time + noise
+    if as_frame:
+        if start_date:
+            stamps = pd.date_range(start_date, periods=n_samples)
+            return pd.DataFrame({"yt": result, "date": stamps})
+        return pd.DataFrame({"yt": result})
+    return result
 
-    Note that internally this is using `fetch_openml` from scikit-learn, which is experimental.
 
-    ==============   ==============
-    Samples total            284807
-    Dimensionality               29
-    Features                   real
-    Target                 int 0, 1
-    ==============   ==============
+def fetch_creditcard(*, cache=True, data_home=None, as_frame=False, return_X_y=False):
+    """Load the creditcard dataset. Download it if necessary.
 
-    The datasets contains transactions made by credit cards in September 2013 by european
-    cardholders. This dataset present transactions that occurred in two days, where we have
-    492 frauds out of 284,807 transactions. The dataset is highly unbalanced, the positive
-    class (frauds) account for 0.172% of all transactions.
+    Note that internally this is using
+    [`fetch_openml`](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.fetch_openml.html) from
+    scikit-learn, which is experimental.
+
+        ==============   ==============
+        Samples total            284807
+        Dimensionality               29
+        Features                   real
+        Target                 int 0, 1
+        ==============   ==============
+
+    The datasets contains transactions made by credit cards in September 2013 by european cardholders.
+    This dataset present transactions that occurred in two days, where we have 492 frauds out of 284,807 transactions.
+    The dataset is highly unbalanced, the positive class (frauds) account for 0.172% of all transactions.
 
     Please cite:
+
         Andrea Dal Pozzolo, Olivier Caelen, Reid A. Johnson and Gianluca Bontempi.
         Calibrating Probability with Undersampling for Unbalanced Classification.
         In Symposium on Computational Intelligence and Data Mining (CIDM), IEEE, 2015
 
-    :param version: integer or 'active', default='active'
-        Version of the dataset. Can only be provided if also ``name`` is given.
-        If 'active' the oldest version that's still active is used. Since
-        there may be more than one active version of a dataset, and those
-        versions may fundamentally be different from one another, setting an
-        exact version is highly recommended.
-    :param cache: boolean, default=True
+    Parameters
+    ----------
+    cache : bool, default=True
         Whether to cache downloaded datasets using joblib.
-    :param data_home: optional, default: None
-        Specify another download and cache folder for the datasets. By default
-        all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
-    :param as_frame: boolean, default=False
-        If True, the data is a pandas DataFrame including columns with
-        appropriate dtypes (numeric, string or categorical). The target is
-        a pandas DataFrame or Series depending on the number of target_columns.
-        The Bunch will contain a ``frame`` attribute with the target and the
-        data. If ``return_X_y`` is True, then ``(data, target)`` will be pandas
-        DataFrames or Series as describe above.
-    :param return_X_y: : boolean, default=False.
-        If True, returns ``(data.data, data.target)`` instead of a Bunch
-        object.
+    data_home : str | None, default=None
+        Specify another download and cache folder for the datasets. By default all scikit-learn data is stored in
+        '~/scikit_learn_data' subfolders.
+    as_frame : bool, default=False
+        If True, the data is a pandas DataFrame including columns with appropriate dtypes (numeric, string or
+        categorical). The target is a pandas DataFrame or Series depending on the number of target_columns.
+        The Bunch will contain a `frame` attribute with the target and the data. If `return_X_y` is True, then
+        `(data, target)` will be pandas DataFrames or Series as describe above.
+    return_X_y : bool, default=False.
+        If True, returns `(data.data, data.target)` instead of a Bunch object.
 
     Returns
     -------
-    :return:
-        Dictionary-like object, with the following attributes.
+    Dictionary-like
+        With the following attributes:
 
          * data
             ndarray, shape (284807, 29) if ``as_frame`` is True, ``data`` is a pandas object.

--- a/sklego/decomposition/pca_reconstruction.py
+++ b/sklego/decomposition/pca_reconstruction.py
@@ -1,12 +1,41 @@
 import numpy as np
-from sklearn.decomposition import PCA
 from sklearn.base import BaseEstimator, OutlierMixin
-from sklearn.utils.validation import check_is_fitted, check_array, FLOAT_DTYPES
+from sklearn.decomposition import PCA
+from sklearn.utils.validation import FLOAT_DTYPES, check_array, check_is_fitted
 
 
 class PCAOutlierDetection(BaseEstimator, OutlierMixin):
-    """
-    Does outlier detection based on the reconstruction error from PCA.
+    """`PCAOutlierDetection` is an outlier detector based on the reconstruction error from PCA.
+
+    If the difference between original and reconstructed data is larger than the `threshold`, the point is
+    considered an outlier.
+
+    Parameters
+    ----------
+    n_components : int | None, default=None
+        Number of components of the PCA model.
+    threshold : float | None, default=None
+        The threshold used for the decision function.
+    variant : Literal["relative", "absolute"], default="relative"
+        The variant used for the difference calculation. "relative" means that the difference between original and
+        reconstructed data is divided by the sum of the original data.
+    whiten : bool, default=False
+        `whiten` parameter of PCA model.
+    svd_solver : Literal["auto", "full", "arpack", "randomized"], default="auto"
+        `svd_solver` parameter of PCA model.
+    tol : float, default=0.0
+        `tol` parameter of PCA model.
+    iterated_power : int | Literal["auto"], default="auto"
+        `iterated_power` parameter of PCA model.
+    random_state : int | None, default=None
+        `random_state` parameter of PCA model.
+
+    Attributes
+    ----------
+    pca_ : PCA
+        The underlying PCA model.
+    offset_ : float
+        The offset used for the decision function.
     """
 
     def __init__(
@@ -30,12 +59,25 @@ class PCAOutlierDetection(BaseEstimator, OutlierMixin):
         self.random_state = random_state
 
     def fit(self, X, y=None):
-        """
-        Fit the model using X as training data.
+        """Fit the `PCAOutlierDetection` model using `X` as training data by fitting the underlying PCA model, and
+        checking the `threshold` value.
 
-        :param X: array-like, shape=(n_columns, n_samples,) training data.
-        :param y: ignored but kept in for pipeline support
-        :return: Returns an instance of self.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features )
+            The training data.
+        y : array-like of shape (n_samples,) or None, default=None
+            Ignored, present for compatibility.
+
+        Returns
+        -------
+        self : PCAOutlierDetection
+            The fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            If `threshold` is `None`.
         """
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         if not self.threshold:
@@ -54,19 +96,23 @@ class PCAOutlierDetection(BaseEstimator, OutlierMixin):
         return self
 
     def transform(self, X):
-        """
-        Uses the underlying PCA method to transform the data.
-        """
+        """Transform the data using the underlying PCA method."""
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         check_is_fitted(self, ["pca_", "offset_"])
         return self.pca_.transform(X)
 
     def difference(self, X):
-        """
-        Shows the calculated difference between original and reconstructed data. Row by row.
+        """Return the calculated difference between original and reconstructed data. Row by row.
 
-        :param X: array-like, shape=(n_columns, n_samples, ) training data.
-        :return: array, shape=(n_samples,) the difference
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features )
+            Data to calculate the difference for.
+
+        Returns
+        -------
+        array-like of shape (n_samples,)
+            The calculated difference.
         """
         check_is_fitted(self, ["pca_", "offset_"])
         reduced = self.pca_.transform(X)
@@ -76,17 +122,29 @@ class PCAOutlierDetection(BaseEstimator, OutlierMixin):
         return diff
 
     def decision_function(self, X):
+        """Calculate the decision function for the data as the difference between `threshold` and the `.difference(X)`
+        (which is the difference between original data and reconstructed data)."""
         return self.threshold - self.difference(X)
 
     def score_samples(self, X):
+        """Calculate the score for the samples"""
         return -self.difference(X)
 
     def predict(self, X):
-        """
-        Predict if a point is an outlier.
+        """Predict if a point is an outlier using fitted estimator.
 
-        :param X: array-like, shape=(n_columns, n_samples, ) training data.
-        :return: array, shape=(n_samples,) the predicted data. 1 for inliers, -1 for outliers.
+        If the difference between original and reconstructed data is larger than the `threshold`, the point is
+        considered an outlier.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples,)
+            The predicted data. 1 for inliers, -1 for outliers.
         """
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         check_is_fitted(self, ["pca_", "offset_"])

--- a/sklego/decomposition/umap_reconstruction.py
+++ b/sklego/decomposition/umap_reconstruction.py
@@ -1,12 +1,41 @@
 import numpy as np
 import umap
 from sklearn.base import BaseEstimator, OutlierMixin
-from sklearn.utils.validation import check_is_fitted, check_array, FLOAT_DTYPES
+from sklearn.utils.validation import FLOAT_DTYPES, check_array, check_is_fitted
 
 
 class UMAPOutlierDetection(BaseEstimator, OutlierMixin):
-    """
-    Does outlier detection based on the reconstruction error from UMAP.
+    """`UMAPOutlierDetection` is an outlier detector based on the reconstruction error from UMAP.
+
+    If the difference between original and reconstructed data is larger than the `threshold`, the point is
+        considered an outlier.
+
+    Parameters
+    ----------
+    n_components : int, default=2
+        Number of components of the UMAP model.
+    threshold : float | None, default=None
+        The threshold used for the decision function.
+    variant : Literal["relative", "absolute"], default="relative"
+        The variant used for the difference calculation. "relative" means that the difference between original and
+        reconstructed data is divided by the sum of the original data.
+    n_neighbors : int, default=15
+        `n_neighbors` parameter of UMAP model.
+    min_dist : float, default=0.1
+        `min_dist` parameter of UMAP model.
+    metric : str, default="euclidean"
+        `metric` parameter of UMAP model
+        (see [UMAP documentation](https://umap-learn.readthedocs.io/en/latest/parameters.html#metric) for the full list
+        of available metrics and more information).
+    random_state : int | None, default=None
+        `random_state` parameter of UMAP model.
+
+    Attributes
+    ----------
+    umap_ : UMAP
+        The underlying UMAP model.
+    offset_ : float
+        The offset used for the decision function.
     """
 
     def __init__(
@@ -28,12 +57,26 @@ class UMAPOutlierDetection(BaseEstimator, OutlierMixin):
         self.random_state = random_state
 
     def fit(self, X, y=None):
-        """
-        Fit the model using X as training data.
+        """Fit the `UMAPOutlierDetection` model using `X` as training data by fitting the underlying UMAP model, and
+        checking the `threshold` value.
 
-        :param X: array-like, shape=(n_columns, n_samples,) training data.
-        :param y: ignored but kept in for pipeline support
-        :return: Returns an instance of self.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features )
+            The training data.
+        y : array-like of shape (n_samples,) or None, default=None
+            Ignored, present for compatibility.
+
+        Returns
+        -------
+        self : UMAPOutlierDetection
+            The fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            - If `n_components` is less than 2.
+            - If `threshold` is `None`.
         """
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         if self.n_components < 2:
@@ -53,19 +96,23 @@ class UMAPOutlierDetection(BaseEstimator, OutlierMixin):
         return self
 
     def transform(self, X):
-        """
-        Uses the underlying UMAP method to transform the data.
-        """
+        """Transform the data using the underlying UMAP method."""
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         check_is_fitted(self, ["umap_", "offset_"])
         return self.umap_.transform(X)
 
     def difference(self, X):
-        """
-        Shows the calculated difference between original and reconstructed data. Row by row.
+        """Return the calculated difference between original and reconstructed data. Row by row.
 
-        :param X: array-like, shape=(n_columns, n_samples, ) training data.
-        :return: array, shape=(n_samples,) the difference
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features )
+            Data to calculate the difference for.
+
+        Returns
+        -------
+        array-like of shape (n_samples,)
+            The calculated difference.
         """
         check_is_fitted(self, ["umap_", "offset_"])
         reduced = self.umap_.transform(X)
@@ -75,11 +122,20 @@ class UMAPOutlierDetection(BaseEstimator, OutlierMixin):
         return diff
 
     def predict(self, X):
-        """
-        Predict if a point is an outlier.
+        """Predict if a point is an outlier using fitted estimator.
 
-        :param X: array-like, shape=(n_columns, n_samples, ) training data.
-        :return: array, shape=(n_samples,) the predicted data. 1 for inliers, -1 for outliers.
+        If the difference between original and reconstructed data is larger than the `threshold`, the point is
+        considered an outlier.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples,)
+            The predicted data. 1 for inliers, -1 for outliers.
         """
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         check_is_fitted(self, ["umap_", "offset_"])

--- a/sklego/dummy.py
+++ b/sklego/dummy.py
@@ -1,41 +1,75 @@
 import numpy as np
 from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.utils import check_X_y
-from sklearn.utils.validation import (
-    check_is_fitted,
-    check_array,
-    check_random_state,
-    FLOAT_DTYPES,
-)
+from sklearn.utils.validation import FLOAT_DTYPES, check_array, check_is_fitted, check_random_state
 
 
 class RandomRegressor(BaseEstimator, RegressorMixin):
-    """
-    A RandomRegressor makes random predictions only based on the "y"
-    value that is seen. The goal is that such a regressor can be used
-    for benchmarking. It should be easily beatable.
+    """A `RandomRegressor` makes random predictions only based on the `y` value that is seen.
 
-    :param str strategy: how we want to select random values, can be "uniform" or "normal"
-    :param int seed: the seed value, default: 42
+    The goal is that such a regressor can be used for benchmarking. It _should be_ easily beatable.
+
+    Parameters
+    ----------
+    strategy : Literal["uniform", "normal"], default="uniform"
+        How we want to select random values, either "uniform" or "normal"
+    random_state : int | None, default=None
+        The seed value used for the random number generator.
+
+    Attributes
+    ----------
+    min_ : float
+        The minimum value of `y` seen during `fit`.
+    max_ : float
+        The maximum value of `y` seen during `fit`.
+    mu_ : float
+        The mean value of `y` seen during `fit`.
+    sigma_ : float
+        The standard deviation of `y` seen during `fit`.
+    dim_ : int
+        The number of features seen during `fit`.
+
+    Examples
+    --------
+    ```py
+    from sklego.dummy import RandomRegressor
+    from sklearn.datasets import make_regression
+
+    X, y = make_regression(n_samples=10, n_features=2, random_state=42)
+
+    RandomRegressor(strategy="uniform", random_state=123).fit(X, y).predict(X).round(2)
+    # array([ 57.63, -66.05, -83.92,  13.88,  64.56, -24.77, 143.33,  54.12,
+    #     -7.34, -34.11])
+
+    RandomRegressor(strategy="normal", random_state=123).fit(X, y).predict(X).round(2)
+    # array([-128.45,   78.05,    7.23, -170.15,  -78.18,  142.9 , -261.39,
+    #     -63.34,  104.68, -106.75])
+    ```
     """
 
     def __init__(self, strategy="uniform", random_state=None):
-        self.allowed_strategies = ("uniform", "normal")
-        self.random_state = random_state
         self.strategy = strategy
+        self.random_state = random_state
+        self.allowed_strategies = ("uniform", "normal")
 
-    def fit(self, X: np.array, y: np.array) -> "RandomRegressor":
-        """
-        Fit the model using X, y as training data.
+    def fit(self, X, y):
+        """Fit the estimator on training data `X` and `y` by calculating and storing the min, max, mean and std of `y`.
 
-        :param X: array-like, shape=(n_columns, n_samples,) training data.
-        :param y: array-like, shape=(n_samples,) training data.
-        :return: Returns an instance of self.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features )
+            The training data.
+        y : array-like of shape (n_samples,)
+            The target values.
+
+        Returns
+        -------
+        self : RandomRegressor
+            The fitted estimator.
         """
+
         if self.strategy not in self.allowed_strategies:
-            raise ValueError(
-                f"strategy {self.strategy} is not in {self.allowed_strategies}"
-            )
+            raise ValueError(f"strategy '{self.strategy}' is not in {self.allowed_strategies}")
         X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         self.dim_ = X.shape[1]
 
@@ -47,20 +81,25 @@ class RandomRegressor(BaseEstimator, RegressorMixin):
         return self
 
     def predict(self, X):
-        """
-        Predict new data by making random guesses.
+        """Predict new data by generating random guesses following the given `strategy` based on the `y` statistics seen
+        during `fit`.
 
-        :param X: array-like, shape=(n_columns, n_samples,) training data.
-        :return: array, shape=(n_samples,) the predicted data
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples,)
+            The predicted data.
         """
         rs = check_random_state(self.random_state)
         check_is_fitted(self, ["dim_", "min_", "max_", "mu_", "sigma_"])
 
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         if X.shape[1] != self.dim_:
-            raise ValueError(
-                f"Unexpected input dimension {X.shape[1]}, expected {self.dim_}"
-            )
+            raise ValueError(f"Unexpected input dimension {X.shape[1]}, expected {self.dim_}")
 
         if self.strategy == "normal":
             return rs.normal(self.mu_, self.sigma_, X.shape[0])

--- a/sklego/linear_model.py
+++ b/sklego/linear_model.py
@@ -16,24 +16,34 @@ from scipy.optimize import minimize
 from scipy.special._ufuncs import expit
 from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.linear_model._base import LinearClassifierMixin
-from sklearn.multiclass import OneVsRestClassifier, OneVsOneClassifier
+from sklearn.multiclass import OneVsOneClassifier, OneVsRestClassifier
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import check_X_y
-from sklearn.utils.validation import (
-    _check_sample_weight,
-    check_is_fitted,
-    check_array,
-    FLOAT_DTYPES,
-    column_or_1d,
-)
+from sklearn.utils.validation import FLOAT_DTYPES, _check_sample_weight, check_array, check_is_fitted, column_or_1d
 
 
 class LowessRegression(BaseEstimator, RegressorMixin):
-    """
-    Does LowessRegression. Note that this *can* get expensive to predict.
+    """`LowessRegression` estimator: LOWESS (Locally Weighted Scatterplot Smoothing) is a type of
+    [local regression](https://en.wikipedia.org/wiki/Local_regression).
 
-    :param sigma: float, how wide we will smooth the data
-    :param span: float, what percentage of the data is to be used. Defaults to using all data.
+    !!! warning
+        This model *can* get expensive to predict.
+        In fact the prediction step needs to compute the distance between each sample to predict `x_i` with all the
+        training samples.
+
+    Parameters
+    ----------
+    sigma : float, default=1.0
+        The bandwidth parameter that determines the width of the smoothing.
+    span : float | None, default=None
+        The fraction of data points to consider during smoothing.
+
+    Attributes
+    ----------
+    X_ : np.ndarray of shape (n_samples, n_features)
+        The training data.
+    y_ : np.ndarray of shape (n_samples,)
+        The target (training) values.
     """
 
     def __init__(self, sigma=1, span=None):
@@ -41,19 +51,31 @@ class LowessRegression(BaseEstimator, RegressorMixin):
         self.span = span
 
     def fit(self, X, y):
-        """
-        Fit the model using X, y as training data.
+        """Fit the estimator on training data `X` and `y` by storing them in `self.X_` and `self.y_`, and
+        validating the parameters.
 
-        :param X: array-like, shape=(n_columns, n_samples, ) training data.
-        :param y: array-like, shape=(n_samples, ) training data.
-        :return: Returns an instance of self.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features )
+            The training data.
+        y : array-like of shape (n_samples,)
+            The target values.
+
+        Returns
+        -------
+        self : LowessRegression
+            The fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            - If `span` is not between 0 and 1.
+            - If `sigma` is negative.
         """
         X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         if self.span is not None:
             if not 0 <= self.span <= 1:
-                raise ValueError(
-                    f"Param `span` must be 0 <= span <= 1, got: {self.span}"
-                )
+                raise ValueError(f"Param `span` must be 0 <= span <= 1, got: {self.span}")
         if self.sigma < 0:
             raise ValueError(f"Param `sigma` must be >= 0, got: {self.sigma}")
         self.X_ = X
@@ -61,20 +83,35 @@ class LowessRegression(BaseEstimator, RegressorMixin):
         return self
 
     def _calc_wts(self, x_i):
-        distances = np.array(
-            [np.linalg.norm(self.X_[i, :] - x_i) for i in range(self.X_.shape[0])]
-        )
+        """Calculate the weights for a single point `x_i` using the training data `self.X_` and the parameters
+        `self.sigma` and `self.span`. The weights are calculated as `np.exp(-(distances**2) / self.sigma)`,
+        where distances are the distances between `x_i` and all the training samples.
+
+        If `self.span` is not None, then the weights are multiplied by
+        `(distances <= np.quantile(distances, q=self.span))`.
+        """
+        distances = np.array([np.linalg.norm(self.X_[i, :] - x_i) for i in range(self.X_.shape[0])])
         weights = np.exp(-(distances**2) / self.sigma)
         if self.span:
             weights = weights * (distances <= np.quantile(distances, q=self.span))
         return weights
 
     def predict(self, X):
-        """
-        Predict using the LowessRegression.
+        """Predict target values for `X` using fitted estimator. This process is expensive because it needs to compute
+        the distance between each sample `x_i` with all the training samples.
 
-        :param X: array-like, shape=(n_columns, n_samples, ) training data.
-        :return: Returns an array of predictions shape=(n_samples,)
+        Then it calculates the weights for **each sample** `x_i` as `np.exp(-(distances**2) / self.sigma)` and finally
+        it computes the weighted average of the `y` values weighted by these weights.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples,)
+            The predicted values.
         """
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         check_is_fitted(self, ["X_", "y_"])
@@ -85,25 +122,55 @@ class LowessRegression(BaseEstimator, RegressorMixin):
 
 
 class ProbWeightRegression(BaseEstimator, RegressorMixin):
-    """
-    This regressor assumes that all input signals in `X` need to be reweighted
-    with weights that sum up to one in order to predict `y`. This can be very useful
-    in combination with `sklego.meta.EstimatorTransformer` because it allows you
-    to construct an ensemble.
+    """`ProbWeightRegression` assumes that all input signals in `X` need to be reweighted with weights that sum up to
+    one in order to predict `y`.
 
-    :param non_negative: boolean, default=True, setting that forces all weights to be >= 0
+    This can be very useful in combination with `sklego.meta.EstimatorTransformer` because it allows to construct
+    an ensemble.
+
+    Parameters
+    ----------
+    non_negative : bool, default=True
+        If True, forces all weights to be non-negative.
+
+    Attributes
+    ----------
+    coefs_ : np.ndarray, shape (n_columns,)
+        The learned coefficients after fitting the model.
+
+    !!! info
+
+        This model requires [`cvxpy`](https://www.cvxpy.org/) to be installed. If you don't have it installed, you can
+        install it with:
+
+        ```bash
+        pip install cvxpy
+        # or pip install scikit-lego"[cvxpy]"
+        ```
     """
 
     def __init__(self, non_negative=True):
         self.non_negative = non_negative
 
     def fit(self, X, y):
-        """
-        Fit the model using X, y as training data.
+        r"""Fit the estimator on training data `X` and `y` by solving the following convex optimization problem:
 
-        :param X: array-like, shape=(n_columns, n_samples, ) training data.
-        :param y: array-like, shape=(n_samples, ) training data.
-        :return: Returns an instance of self.
+        $$\begin{array}{ll}{\operatorname{minimize}} & {\sum_{i=1}^{N}\left(\mathbf{x}_{i}
+        \boldsymbol{\beta}-y_{i}\right)^{2}} \\
+        {\text { subject to }} & {\sum_{j=1}^{p} \beta_{j}=1} \\
+        {(\text{If non_negative=True})} & {\beta_{j} \geq 0, \quad j=1, \ldots, p} \end{array}$$
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features )
+            The training data.
+        y : array-like of shape (n_samples,)
+            The target values.
+
+        Returns
+        -------
+        self : ProbWeightRegression
+            The fitted estimator.
         """
         X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
 
@@ -121,11 +188,17 @@ class ProbWeightRegression(BaseEstimator, RegressorMixin):
         return self
 
     def predict(self, X):
-        """
-        Predict using ProbWeightRegression.
+        """Predict target values for `X` using fitted estimator by multiplying `X` with the learned coefficients.
 
-        :param X: array-like, shape=(n_columns, n_samples, ) training data.
-        :return: Returns an array of predictions shape=(n_samples,)
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples,)
+            The predicted data.
         """
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         check_is_fitted(self, ["coefs_"])
@@ -133,6 +206,60 @@ class ProbWeightRegression(BaseEstimator, RegressorMixin):
 
 
 class DeadZoneRegressor(BaseEstimator, RegressorMixin):
+    r"""The `DeadZoneRegressor` estimator implements a regression model that incorporates a _dead zone effect_ for
+    improving the robustness of regression predictions.
+
+    The dead zone effect allows the model to reduce the impact of small errors in the training data on the regression
+    results, which can be particularly useful when dealing with noisy or unreliable data.
+
+    The estimator minimizes the following loss function using gradient descent:
+
+    $$\frac{1}{n} \sum_{i=1}^{n} \text{deadzone}\left(\left|X_i \cdot w - y_i\right|\right)$$
+
+    where:
+
+    $$\text{deadzone}(e) =
+    \begin{cases}
+    e & \text{if } e > \text{threshold} \text{ and effect="linear"} \\
+    e^2 & \text{if } e > \text{threshold} \text{ and effect="quadratic"} \\
+    0 & \text{otherwise}
+    \end{cases}
+    $$
+
+    Parameters
+    ----------
+    threshold : float, default=0.3
+        The threshold value for the dead zone effect.
+    relative : bool, default=False
+        If True, the threshold is relative to the target value. Namely the _dead zone effect_ is applied to the
+        relative error between the predicted and target values.
+    effect : Literal["linear", "quadratic"], default="linear"
+        The type of dead zone effect to apply. It can be one of the following:
+
+        - "linear": the errors within the threshold have no impact (their contribution is effectively zero), and errors
+            outside the threshold are penalized linearly.
+        - "quadratic": the errors within the threshold have no impact (their contribution is effectively zero), and
+            errors outside the threshold are penalized quadratically (squared).
+    n_iter : int, default=2000
+        The number of iterations to run the gradient descent algorithm.
+    stepsize : float, default=0.01
+        The step size for the gradient descent algorithm.
+    check_grad : bool, default=False
+        If True, check the gradients numerically, _just to be safe_.
+
+    Attributes
+    ----------
+    coefs_ : np.ndarray, shape (n_columns,)
+        The learned coefficients after fitting the model.
+    loss_log_ : np.ndarray, shape (n_iter,)
+        A log of training losses recorded during the optimization process.
+    wts_log_ : np.ndarray, shape (n_iter, n_samples)
+        A log of weights for each feature recorded at each iteration of the optimization.
+    deriv_log_ : np.ndarray, shape (n_iter, n_samples)
+        A log of gradients of the training loss with respect to the weights recorded at each iteration of the
+        optimization.
+    """
+
     def __init__(
         self,
         threshold=0.3,
@@ -155,12 +282,24 @@ class DeadZoneRegressor(BaseEstimator, RegressorMixin):
         self.coefs_ = None
 
     def fit(self, X, y):
-        """
-        Fit the model using X, y as training data.
+        """Fit the estimator on training data `X` and `y` by optimizing the loss function using gradient descent.
 
-        :param X: array-like, shape=(n_columns, n_samples, ) training data.
-        :param y: array-like, shape=(n_samples, ) training data.
-        :return: Returns an instance of self.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features )
+            The training data.
+        y : array-like of shape (n_samples,)
+            The target values.
+
+        Returns
+        -------
+        self : DeadZoneRegressor
+            The fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            If `effect` is not one of "linear", "quadratic" or "constant".
         """
         X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         if self.effect not in self.allowed_effects:
@@ -170,9 +309,7 @@ class DeadZoneRegressor(BaseEstimator, RegressorMixin):
             if self.effect == "linear":
                 return np.where(errors > self.threshold, errors, np.zeros(errors.shape))
             if self.effect == "quadratic":
-                return np.where(
-                    errors > self.threshold, errors**2, np.zeros(errors.shape)
-                )
+                return np.where(errors > self.threshold, errors**2, np.zeros(errors.shape))
 
         def training_loss(weights):
             diff = np.abs(np.dot(X, weights) - y)
@@ -203,11 +340,17 @@ class DeadZoneRegressor(BaseEstimator, RegressorMixin):
         return self
 
     def predict(self, X):
-        """
-        Predict using DeadZoneRegressor.
+        """Predict target values for `X` using fitted estimator by multiplying `X` with the learned coefficients.
 
-        :param X: array-like, shape=(n_columns, n_samples, ) training data.
-        :return: Returns an array of predictions shape=(n_samples,)
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples,)
+            The predicted data.
         """
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         check_is_fitted(self, ["coefs_"])
@@ -215,6 +358,48 @@ class DeadZoneRegressor(BaseEstimator, RegressorMixin):
 
 
 class _FairClassifier(BaseEstimator, LinearClassifierMixin):
+    """Base class for fair classifiers that address sensitive attribute fairness.
+
+    This base class provides a foundation for fair classifiers that aim to mitigate bias and discrimination by taking
+    into account sensitive attributes during the classification process.
+
+    This estimator works by solving a constrained optimization problem that maximizes the log-likelihood of the
+    training data while satisfying fairness constraints.
+
+    !!! warning
+        The classification problem should be a binary one.
+
+    Parameters
+    ----------
+    sensitive_cols : List[str] | List[int] | None, default=None
+        A list of column names or column indexes in the input data that represent sensitive attributes.
+    C : float, default=1.0
+        Inverse of regularization strength; must be a positive float. Smaller values specify stronger regularization.
+    penalty : Literal["l1", "none"], default="l1"
+        The type of penalty to apply to the model. "l1" applies L1 regularization, while "none" disables regularization.
+    fit_intercept : bool, default=True
+        Whether or not to fit an intercept term. If True, an intercept term is added to the model.
+    max_iter : int, default=100
+        Maximum number of iterations for the solver.
+    train_sensitive_cols : bool, default=False
+        Whether or not to include sensitive columns during training. If False, sensitive columns are removed from the
+        input data during training.
+
+    Attributes
+    ----------
+    sensitive_col_idx_ : array
+        Indices of columns in the input data that correspond to sensitive attributes.
+    classes_ : array-like of shape (n_classes,)
+        The classes seen at `fit`.
+
+    Note
+    ----
+    Subclasses of `_FairClassifier` should implement the `constraints` method to specify fairness constraints.
+    This class primarily handles the logistic regression optimization and preprocessing steps.
+
+    `_FairClassifier` should not be used directly; it serves as a base class for fair classification models.
+    """
+
     def __init__(
         self,
         sensitive_cols=None,
@@ -232,16 +417,33 @@ class _FairClassifier(BaseEstimator, LinearClassifierMixin):
         self.C = C
 
     def fit(self, X, y):
+        """Fit the estimator on training data `X` and `y`.
+
+        It handles preprocessing and optimization.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features )
+            The training data.
+        y : array-like of shape (n_samples,)
+            The target values.
+
+        Returns
+        -------
+        self : _FairClassifier
+            The fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            If `penalty` is not one of "l1" or "none".
+        """
         if self.penalty not in ["l1", "none"]:
-            raise ValueError(
-                f"penalty should be either 'l1' or 'none', got {self.penalty}"
-            )
+            raise ValueError(f"penalty should be either 'l1' or 'none', got {self.penalty}")
 
         self.sensitive_col_idx_ = self.sensitive_cols
         if isinstance(X, pd.DataFrame):
-            self.sensitive_col_idx_ = [
-                i for i, name in enumerate(X.columns) if name in self.sensitive_cols
-            ]
+            self.sensitive_col_idx_ = [i for i, name in enumerate(X.columns) if name in self.sensitive_cols]
         X, y = check_X_y(X, y, accept_large_sparse=False)
 
         sensitive = X[:, self.sensitive_col_idx_]
@@ -264,20 +466,17 @@ class _FairClassifier(BaseEstimator, LinearClassifierMixin):
         return self
 
     def constraints(self, y_hat, y_true, sensitive, n_obs):
-        raise NotImplementedError(
-            "subclasses of _FairClassifier should implement constraints"
-        )
+        raise NotImplementedError("subclasses of `_FairClassifier` should implement constraints")
 
     def _solve(self, sensitive, X, y):
+        """Solve the optimization problem for the fair classifier."""
         n_obs, n_features = X.shape
         theta = cp.Variable(n_features)
         y_hat = X @ theta
 
         log_likelihood = cp.sum(
             cp.multiply(y, y_hat)
-            - cp.log_sum_exp(
-                cp.hstack([np.zeros((n_obs, 1)), cp.reshape(y_hat, (n_obs, 1))]), axis=1
-            )
+            - cp.log_sum_exp(cp.hstack([np.zeros((n_obs, 1)), cp.reshape(y_hat, (n_obs, 1))]), axis=1)
         )
         if self.penalty == "l1":
             log_likelihood -= cp.sum((1 / self.C) * cp.norm(theta[1:]))
@@ -300,6 +499,20 @@ class _FairClassifier(BaseEstimator, LinearClassifierMixin):
             self.intercept_ = np.array([0.0])
 
     def predict_proba(self, X):
+        """Predict class probabilities for `X`.
+
+        This method predicts class probabilities for input data `X`.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples, 2)
+            The predicted class probabilities for each data point.
+        """
         decision = self.decision_function(X)
         decision_2d = np.c_[-decision, decision]
         return expit(decision_2d)
@@ -317,50 +530,53 @@ class _FairClassifier(BaseEstimator, LinearClassifierMixin):
 
 
 class DemographicParityClassifier(BaseEstimator, LinearClassifierMixin):
-    r"""
-    A logistic regression classifier which can be constrained on demographic parity (p% score).
+    r"""`DemographicParityClassifier` is a logistic regression classifier which can be constrained on demographic
+    parity (p% score).
 
-    Minimizes the Log loss while constraining the correlation between the specified `sensitive_cols` and the
+    It minimizes the log loss while constraining the correlation between the specified `sensitive_cols` and the
     distance to the decision boundary of the classifier.
 
-    Only works for binary classification problems
+    !!! warning
+        This classifier only works for binary classification problems.
 
-    .. math::
-        \begin{array}{cl}{\operatorname{minimize}} & -\sum_{i=1}^{N} \log p\left(y_{i} | \mathbf{x}_{i},
+    $$\begin{array}{cl}{\operatorname{minimize}} & -\sum_{i=1}^{N} \log p\left(y_{i} | \mathbf{x}_{i},
         \boldsymbol{\theta}\right) \\
-        {\text { subject to }} & {\frac{1}{N} \sum_{i=1}^{N}\left(\mathbf{z}_{i}-\overline{\mathbf{z}}\right) d
-        \boldsymbol{\theta}\left(\mathbf{x}_{i}\right) \leq \mathbf{c}} \\
+        {\text { subject to }} & {\frac{1}{N} \sum_{i=1}^{N}\left(\mathbf{z}_{i}-\overline{\mathbf{z}}\right)
+        d_\boldsymbol{\theta}\left(\mathbf{x}_{i}\right) \leq \mathbf{c}} \\
         {} & {\frac{1}{N} \sum_{i=1}^{N}\left(\mathbf{z}_{i}-\overline{\mathbf{z}}\right)
-        d_{\boldsymbol{\theta}}\left(\mathbf{x}_{i}\right) \geq-\mathbf{c}}\end{array}
+        d_{\boldsymbol{\theta}}\left(\mathbf{x}_{i}\right) \geq-\mathbf{c}}\end{array}$$
 
-    Source:
-    - M. Zafar et al. (2017), Fairness Constraints: Mechanisms for Fair Classification
+    Parameters
+    ----------
+    covariance_threshold : float | None
+        The maximum allowed covariance between the sensitive attributes and the distance to the decision boundary.
+        If set to None, no fairness constraint is enforced.
+    sensitive_cols : List[str] | List[int] | None, default=None
+        List of sensitive column names (if X is a dataframe) or a list of column indices (if X is a numpy array).
+    C : float, default=1.0
+        Inverse of regularization strength; must be a positive float. Like in support vector machines, smaller values
+        specify stronger regularization.
+    penalty : Literal["l1", "none"], default="l1"
+        Used to specify the norm used in the penalization.
+    fit_intercept : bool, default=True
+        Whether or not a constant term (a.k.a. bias or intercept) should be added to the decision function.
+    max_iter : int, default=100
+        Maximum number of iterations taken for the solvers to converge.
+    train_sensitive_cols : bool, default=False
+        Indicates whether the model should use the sensitive columns in the fit step.
+    multi_class : Literal["ovr", "ovo"], default="ovr"
+        The method to use for multiclass predictions.
+    n_jobs : int | None, default=1
+        The amount of parallel jobs that should be used to fit the model.
 
-    :param covariance_threshold:
-        The maximum allowed covariance between the sensitive attributes and the distance to the
-        decision boundary. If set to None, no fairness constraint is enforced
-    :param sensitive_cols:
-        List of sensitive column names(when X is a dataframe)
-        or a list of column indices when X is a numpy array.
-    :param C:
-        Inverse of regularization strength; must be a positive float.
-        Like in support vector machines, smaller values specify stronger regularization.
-    :param penalty: Used to specify the norm used in the penalization. Expects 'none' or 'l1'
-    :param fit_intercept: Specifies if a constant (a.k.a. bias or intercept) should be added to the decision function.
-    :param max_iter: Maximum number of iterations taken for the solvers to converge.
-    :param train_sensitive_cols: Indicates whether the model should use the sensitive columns in the fit step.
-    :param multi_class: The method to use for multiclass predictions
-    :param n_jobs: The amount of parallel jobs that should be used to fit multiclass models
-
+    Source
+    ------
+    M. Zafar et al. (2017), Fairness Constraints: Mechanisms for Fair Classification
     """
 
     def __new__(cls, *args, multi_class="ovr", n_jobs=1, **kwargs):
-        multiclass_meta = {"ovr": OneVsRestClassifier, "ovo": OneVsOneClassifier}[
-            multi_class
-        ]
-        return multiclass_meta(
-            _DemographicParityClassifier(*args, **kwargs), n_jobs=n_jobs
-        )
+        multiclass_meta = {"ovr": OneVsRestClassifier, "ovo": OneVsOneClassifier}[multi_class]
+        return multiclass_meta(_DemographicParityClassifier(*args, **kwargs), n_jobs=n_jobs)
 
 
 @deprecated(
@@ -373,6 +589,15 @@ class FairClassifier(DemographicParityClassifier):
 
 
 class _DemographicParityClassifier(_FairClassifier):
+    r"""Classifier for Demographic Parity fairness constraint.
+
+    This classifier extends the `_FairClassifier` and adds a Demographic Parity fairness constraint.
+    Demographic Parity ensures that the probability of a positive outcome is the same for all groups defined by
+    sensitive attributes.
+
+    The class implements Demographic Parity fairness constraint to the `_FairClassifier` optimization problem.
+    """
+
     def __init__(
         self,
         covariance_threshold,
@@ -395,6 +620,7 @@ class _DemographicParityClassifier(_FairClassifier):
         self.covariance_threshold = covariance_threshold
 
     def constraints(self, y_hat, y_true, sensitive, n_obs):
+        """Implement the Demographic Parity fairness constraint."""
         if self.covariance_threshold is not None:
             dec_boundary_cov = y_hat @ (sensitive - np.mean(sensitive, axis=0)) / n_obs
             return [cp.abs(dec_boundary_cov) <= self.covariance_threshold]
@@ -403,51 +629,53 @@ class _DemographicParityClassifier(_FairClassifier):
 
 
 class EqualOpportunityClassifier(BaseEstimator, LinearClassifierMixin):
-    r"""
-    A logistic regression classifier which can be constrained on equal opportunity score.
+    r"""`EqualOpportunityClassifier` is a logistic regression classifier which can be constrained on equal opportunity
+    score.
 
-    Minimizes the Log loss while constraining the correlation between the specified `sensitive_cols` and the
+    It minimizes the log loss while constraining the correlation between the specified `sensitive_cols` and the
     distance to the decision boundary of the classifier for those examples that have a y_true of 1.
 
-    Only works for binary classification problems
+    !!! warning
+        This classifier only works for binary classification problems.
 
-    .. math::
-       \begin{array}{cl}{\operatorname{minimize}} & -\sum_{i=1}^{N} \log p\left(y_{i} | \mathbf{x}_{i},
+    $$\begin{array}{cl}{\operatorname{minimize}} & -\sum_{i=1}^{N} \log p\left(y_{i} | \mathbf{x}_{i},
         \boldsymbol{\theta}\right) \\
-        {\text { subject to }} & {\frac{1}{POS} \sum_{i=1}^{POS}\left(\mathbf{z}_{i}-\overline{\mathbf{z}}\right) d
-        \boldsymbol{\theta}\left(\mathbf{x}_{i}\right) \leq \mathbf{c}} \\
+        {\text { subject to }} & {\frac{1}{POS} \sum_{i=1}^{POS}\left(\mathbf{z}_{i}-\overline{\mathbf{z}}\right)
+        d_\boldsymbol{\theta}\left(\mathbf{x}_{i}\right) \leq \mathbf{c}} \\
         {} & {\frac{1}{POS} \sum_{i=1}^{POS}\left(\mathbf{z}_{i}-\overline{\mathbf{z}}\right)
-        d_{\boldsymbol{\theta}}\left(\mathbf{x}_{i}\right) \geq-\mathbf{c}}\end{array}
+        d_{\boldsymbol{\theta}}\left(\mathbf{x}_{i}\right) \geq-\mathbf{c}}\end{array}$$
 
-    where POS is the subset of the population where y_true = 1
+    where POS is the subset of the population where $\text{y_true} = 1$
 
-
-    :param covariance_threshold:
-        The maximum allowed covariance between the sensitive attributes and the distance to the
-        decision boundary. If set to None, no fairness constraint is enforced
-    :param positive_target: The name of the class which is associated with a positive outcome
-    :param sensitive_cols:
-        List of sensitive column names(when X is a dataframe)
-        or a list of column indices when X is a numpy array.
-    :param C:
-        Inverse of regularization strength; must be a positive float.
-        Like in support vector machines, smaller values specify stronger regularization.
-    :param penalty: Used to specify the norm used in the penalization. Expects 'none' or 'l1'
-    :param fit_intercept: Specifies if a constant (a.k.a. bias or intercept) should be added to the decision function.
-    :param max_iter: Maximum number of iterations taken for the solvers to converge.
-    :param train_sensitive_cols: Indicates whether the model should use the sensitive columns in the fit step.
-    :param multi_class: The method to use for multiclass predictions
-    :param n_jobs: The amount of parallel jobs that should be used to fit multiclass models
-
+    Parameters
+    ----------
+    covariance_threshold : float | None
+        The maximum allowed covariance between the sensitive attributes and the distance to the decision boundary.
+        If set to None, no fairness constraint is enforced.
+    positive_target : int
+        The name of the class which is associated with a positive outcome
+    sensitive_cols : List[str] | List[int] | None, default=None
+        List of sensitive column names (if X is a dataframe) or a list of column indices (if X is a numpy array).
+    C : float, default=1.0
+        Inverse of regularization strength; must be a positive float. Like in support vector machines, smaller values
+        specify stronger regularization.
+    penalty : Literal["l1", "none"], default="l1"
+        Used to specify the norm used in the penalization.
+    fit_intercept : bool, default=True
+        Whether or not a constant term (a.k.a. bias or intercept) should be added to the decision function.
+    max_iter : int, default=100
+        Maximum number of iterations taken for the solvers to converge.
+    train_sensitive_cols : bool, default=False
+        Indicates whether the model should use the sensitive columns in the fit step.
+    multi_class : Literal["ovr", "ovo"], default="ovr"
+        The method to use for multiclass predictions.
+    n_jobs : int | None, default=1
+        The amount of parallel jobs that should be used to fit the model.
     """
 
     def __new__(cls, *args, multi_class="ovr", n_jobs=1, **kwargs):
-        multiclass_meta = {"ovr": OneVsRestClassifier, "ovo": OneVsOneClassifier}[
-            multi_class
-        ]
-        return multiclass_meta(
-            _EqualOpportunityClassifier(*args, **kwargs), n_jobs=n_jobs
-        )
+        multiclass_meta = {"ovr": OneVsRestClassifier, "ovo": OneVsOneClassifier}[multi_class]
+        return multiclass_meta(_EqualOpportunityClassifier(*args, **kwargs), n_jobs=n_jobs)
 
 
 class _EqualOpportunityClassifier(_FairClassifier):
@@ -478,10 +706,7 @@ class _EqualOpportunityClassifier(_FairClassifier):
             n_obs = len(y_true[y_true == self.positive_target])
             dec_boundary_cov = (
                 y_hat[y_true == self.positive_target]
-                @ (
-                    sensitive[y_true == self.positive_target]
-                    - np.mean(sensitive, axis=0)
-                )
+                @ (sensitive[y_true == self.positive_target] - np.mean(sensitive, axis=0))
                 / n_obs
             )
             return [cp.abs(dec_boundary_cov) <= self.covariance_threshold]
@@ -490,46 +715,45 @@ class _EqualOpportunityClassifier(_FairClassifier):
 
 
 class BaseScipyMinimizeRegressor(BaseEstimator, RegressorMixin, ABC):
-    """
-    Base class for regressors relying on scipy's minimize method. Derive a class from this one and give it the function to be minimized.
+    """Abstract base class for regressors relying on Scipy's
+    [minimize method](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html) to minimize a
+    (custom) loss function.
+
+    Derive a class from this one and give it the function to be minimized. The derived class should implement the
+    `_get_objective` method, which should return the loss function and its gradient.
+
+    !!! info
+        This implementation uses
+        [scipy.optimize.minimize](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
 
     Parameters
     ----------
     alpha : float, default=0.0
-        Constant that multiplies the penalty terms. Defaults to 1.0.
-
+        Constant that multiplies the penalty terms.
     l1_ratio : float, default=0.0
-        The ElasticNet mixing parameter, with ``0 <= l1_ratio <= 1``. For
-        ``l1_ratio = 0`` the penalty is an L2 penalty. ``For l1_ratio = 1`` it
-        is an L1 penalty.  For ``0 < l1_ratio < 1``, the penalty is a
-        combination of L1 and L2.
+        The ElasticNet mixing parameter, with `0 <= l1_ratio <= 1`:
 
+        - `l1_ratio = 0` is equivalent to an L2 penalty.
+        - `l1_ratio = 1` is equivalent to an L1 penalty.
+        - `0 < l1_ratio < 1` is the combination of L1 and L2.
     fit_intercept : bool, default=True
-        Whether to calculate the intercept for this model. If set
-        to False, no intercept will be used in calculations
+        Whether to calculate the intercept for this model. If set to False, no intercept will be used in calculations
         (i.e. data is expected to be centered).
-
     copy_X : bool, default=True
-        If True, X will be copied; else, it may be overwritten.
-
+        If True, `X` will be copied; else, it may be overwritten.
     positive : bool, default=False
         When set to True, forces the coefficients to be positive.
-
-    method : str, default="SLSQP"
-        Type of solver. Should be one of "SLSQP", "TNC", "L-BFGS-B".
+    method : Literal["SLSQP", "TNC", "L-BFGS-B"], default="SLSQP"
+        Type of solver to use for optimization.
 
     Attributes
     ----------
-    coef_ : np.array of shape (n_features,)
+    coef_ : np.ndarray of shape (n_features,)
         Estimated coefficients of the model.
-
     intercept_ : float
-        Independent term in the linear model. Set to 0.0 if fit_intercept = False.
-
-    Notes
-    -----
-    This implementation uses scipy.optimize.minimize, see
-    https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html.
+        Independent term in the linear model. Set to 0.0 if `fit_intercept = False`.
+    n_features_in_ : int
+        Number of features seen during `fit`.
     """
 
     def __init__(
@@ -547,75 +771,60 @@ class BaseScipyMinimizeRegressor(BaseEstimator, RegressorMixin, ABC):
         self.copy_X = copy_X
         self.positive = positive
         if method not in ("SLSQP", "TNC", "L-BFGS-B"):
-            raise ValueError(
-                f'method should be one of "SLSQP", "TNC", "L-BFGS-B", '
-                f"got {method} instead"
-            )
+            raise ValueError(f'method should be one of "SLSQP", "TNC", "L-BFGS-B", ' f"got {method} instead")
         self.method = method
 
     @abstractmethod
     def _get_objective(self, X, y, sample_weight):
-        """
-        Produce the loss function to be minimized, and its gradient to speed up computations.
+        """Produce the loss function to be minimized, and its gradient to speed up computations.
 
         Parameters
         ----------
-        X : np.array of shape (n_samples, n_features)
+        X : np.ndarray of shape (n_samples, n_features)
             The training data.
-
-        y : np.array, 1-dimensional
+        y : np.ndarray of shape (n_samples,)
             The target values.
-
-        sample_weight : Optional[np.array], default=None
+        sample_weight : np.ndarray of shape (n_samples,) | None, default=None
             Individual weights for each sample.
 
         Returns
         -------
-        loss : Callable[[np.array], float]
+        loss : Callable[[np.ndarray], float]
             The loss function to be minimized.
-
-        grad_loss : Callable[[np.array], np.array]
+        grad_loss : Callable[[np.ndarray], np.ndarray]
             The gradient of the loss function. Speeds up finding the minimum.
         """
+        ...
 
     def _regularized_loss(self, params):
-        return +self.alpha * self.l1_ratio * np.sum(
-            np.abs(params)
-        ) + 0.5 * self.alpha * (1 - self.l1_ratio) * np.sum(params**2)
-
-    def _regularized_grad_loss(self, params):
-        return (
-            +self.alpha * self.l1_ratio * np.sign(params)
-            + self.alpha * (1 - self.l1_ratio) * params
+        return +self.alpha * self.l1_ratio * np.sum(np.abs(params)) + 0.5 * self.alpha * (1 - self.l1_ratio) * np.sum(
+            params**2
         )
 
+    def _regularized_grad_loss(self, params):
+        return +self.alpha * self.l1_ratio * np.sign(params) + self.alpha * (1 - self.l1_ratio) * params
+
     def fit(self, X, y, sample_weight=None):
-        """
-        Fit the model using the chosen algorithm.
+        """Fit the linear model on training data `X` and `y` by optimizing the loss function using gradient descent.
 
         Parameters
         ----------
-        X : np.array of shape (n_samples, n_features)
+        X : array-like of shape (n_samples, n_features )
             The training data.
-
-        y : np.array, 1-dimensional
+        y : array-like of shape (n_samples,)
             The target values.
-
-        sample_weight : Optional[np.array], default=None
+        sample_weight : array-like of shape (n_samples,) | None, default=None
             Individual weights for each sample.
 
         Returns
         -------
-        Fitted regressor.
+        self : BaseScipyMinimizeRegressor
+            Fitted linear model.
         """
         X_, grad_loss, loss = self._prepare_inputs(X, sample_weight, y)
 
         d = X_.shape[1] - self.n_features_in_  # This is either zero or one.
-        bounds = (
-            self.n_features_in_ * [(0, np.inf)] + d * [(-np.inf, np.inf)]
-            if self.positive
-            else None
-        )
+        bounds = self.n_features_in_ * [(0, np.inf)] + d * [(-np.inf, np.inf)] if self.positive else None
         minimize_result = minimize(
             loss,
             x0=np.zeros(self.n_features_in_ + d),
@@ -637,6 +846,11 @@ class BaseScipyMinimizeRegressor(BaseEstimator, RegressorMixin, ABC):
         return self
 
     def _prepare_inputs(self, X, sample_weight, y):
+        """Prepare the inputs for the optimization problem.
+
+        This method is called by `fit` to prepare the inputs for the optimization problem. It adds an intercept column
+        to `X` if `fit_intercept=True`, and returns the loss function and its gradient.
+        """
         X, y = check_X_y(X, y, y_numeric=True)
         sample_weight = _check_sample_weight(sample_weight, X)
         self.n_features_in_ = X.shape[1]
@@ -654,18 +868,17 @@ class BaseScipyMinimizeRegressor(BaseEstimator, RegressorMixin, ABC):
         return X_, grad_loss, loss
 
     def predict(self, X):
-        """
-        Predict using the linear model.
+        """Predict target values for `X` using fitted linear model by multiplying `X` with the learned coefficients.
 
         Parameters
         ----------
-        X : np.array, shape (n_samples, n_features)
-            Samples to get predictions of.
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
 
         Returns
         -------
-        y : np.array, shape (n_samples,)
-            The predicted values.
+        array-like of shape (n_samples,)
+            The predicted data.
         """
         check_is_fitted(self)
         X = check_array(X)
@@ -674,76 +887,79 @@ class BaseScipyMinimizeRegressor(BaseEstimator, RegressorMixin, ABC):
 
 
 class ImbalancedLinearRegression(BaseScipyMinimizeRegressor):
-    r"""
-    Linear regression where overestimating is `overestimation_punishment_factor` times worse than underestimating.
+    r"""Linear regression where overestimating is `overestimation_punishment_factor` times worse than underestimating.
 
-    A value of `overestimation_punishment_factor=5` implies that overestimations by the model are penalized with a factor of 5
-    while underestimations have a default factor of 1. The formula optimized for is
+    A value of `overestimation_punishment_factor=5` implies that overestimations by the model are penalized with a
+    factor of 5 while underestimations have a default factor of 1. The formula optimized for is
 
-    .. math::
-        \frac{1}{2 N} \|s \circ (y - Xw) \|_2^2 + \alpha \cdot l_1 \cdot\|w\|_1 + \frac{\alpha}{2} \cdot (1-l_1)\cdot \|w\|_2^2
+    $$\frac{1}{2 N} \|s \circ (y - Xw) \|_2^2 + \alpha \cdot l_1 \cdot\|w\|_1 + \frac{\alpha}{2} \cdot (1-l_1)\cdot
+    \|w\|_2^2$$
 
-    where `circ` is component-wise multiplication and s is a vector with value overestimation_punishment_factor if y - Xw < 0, else 1.
+    where $\circ$ is component-wise multiplication and
 
-    ImbalancedLinearRegression fits a linear model to minimize the residual sum of squares between
-    the observed targets in the dataset, and the targets predicted by the linear approximation.
+    $$ s = \begin{cases}
+    \text{overestimation_punishment_factor} & \text{if } y - Xw < 0 \\
+    1 & \text{otherwise}
+    \end{cases}
+    $$
+
+    `ImbalancedLinearRegression` fits a linear model to minimize the residual sum of squares between the observed
+    targets in the dataset, and the targets predicted by the linear approximation.
     Compared to normal linear regression, this approach allows for a different treatment of over or under estimations.
+
+    !!! info
+        This implementation uses
+        [scipy.optimize.minimize](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
 
     Parameters
     ----------
     alpha : float, default=0.0
-        Constant that multiplies the penalty terms. Defaults to 1.0.
-
+        Constant that multiplies the penalty terms.
     l1_ratio : float, default=0.0
-        The ElasticNet mixing parameter, with ``0 <= l1_ratio <= 1``. For
-        ``l1_ratio = 0`` the penalty is an L2 penalty. ``For l1_ratio = 1`` it
-        is an L1 penalty.  For ``0 < l1_ratio < 1``, the penalty is a
-        combination of L1 and L2.
+        The ElasticNet mixing parameter, with `0 <= l1_ratio <= 1`:
 
+        - `l1_ratio = 0` is equivalent to an L2 penalty.
+        - `l1_ratio = 1` is equivalent to an L1 penalty.
+        - `0 < l1_ratio < 1` is the combination of L1 and L2.
     fit_intercept : bool, default=True
-        Whether to calculate the intercept for this model. If set
-        to False, no intercept will be used in calculations
+        Whether to calculate the intercept for this model. If set to False, no intercept will be used in calculations
         (i.e. data is expected to be centered).
-
     copy_X : bool, default=True
-        If True, X will be copied; else, it may be overwritten.
-
+        If True, `X` will be copied; else, it may be overwritten.
     positive : bool, default=False
         When set to True, forces the coefficients to be positive.
-
-    method : str, default="SLSQP"
-        Type of solver. Should be one of "SLSQP", "TNC", "L-BFGS-B".
-
-    overestimation_punishment_factor : float, default=1
+    method : Literal["SLSQP", "TNC", "L-BFGS-B"], default="SLSQP"
+        Type of solver to use for optimization.
+    overestimation_punishment_factor : float, default=1.0
         Factor to punish overestimations more (if the value is larger than 1) or less (if the value is between 0 and 1).
 
     Attributes
     ----------
-    coef_ : np.array of shape (n_features,)
+    coef_ : np.ndarray of shape (n_features,)
         Estimated coefficients of the model.
-
     intercept_ : float
-        Independent term in the linear model. Set to 0.0 if fit_intercept = False.
-
-    Notes
-    -----
-    This implementation uses scipy.optimize.minimize, see
-    https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html.
+        Independent term in the linear model. Set to 0.0 if `fit_intercept = False`.
+    n_features_in_ : int
+        Number of features seen during `fit`.
 
     Examples
     --------
-    >>> import numpy as np
-    >>> np.random.seed(0)
-    >>> X = np.random.randn(100, 4)
-    >>> y = X @ np.array([1, 2, 3, 4]) + 2*np.random.randn(100)
-    >>> over_bad = ImbalancedLinearRegression(overestimation_punishment_factor=50).fit(X, y)
-    >>> over_bad.coef_
-    array([0.36267036, 1.39526844, 3.4247146 , 3.93679175])
+    ```py
+    import numpy as np
+    from sklego.linear_model import ImbalancedLinearRegression
 
-    >>> under_bad = ImbalancedLinearRegression(overestimation_punishment_factor=0.01).fit(X, y)
-    >>> under_bad.coef_
-    array([0.73519586, 1.28698197, 2.61362614, 4.35989806])
+    np.random.seed(0)
+    X = np.random.randn(100, 4)
+    y = X @ np.array([1, 2, 3, 4]) + 2*np.random.randn(100)
 
+    over_bad = ImbalancedLinearRegression(overestimation_punishment_factor=50).fit(X, y)
+    over_bad.coef_
+    # array([0.36267036, 1.39526844, 3.4247146 , 3.93679175])
+
+    under_bad = ImbalancedLinearRegression(overestimation_punishment_factor=0.01).fit(X, y)
+    under_bad.coef_
+    # array([0.73519586, 1.28698197, 2.61362614, 4.35989806])
+    ```
     """
 
     def __init__(
@@ -769,11 +985,7 @@ class ImbalancedLinearRegression(BaseScipyMinimizeRegressor):
 
         def grad_imbalanced_loss(params):
             return (
-                -(
-                    sample_weight
-                    * np.where(X @ params > y, self.overestimation_punishment_factor, 1)
-                    * (y - X @ params)
-                )
+                -(sample_weight * np.where(X @ params > y, self.overestimation_punishment_factor, 1) * (y - X @ params))
                 @ X
                 / X.shape[0]
             ) + self._regularized_grad_loss(params)
@@ -782,71 +994,83 @@ class ImbalancedLinearRegression(BaseScipyMinimizeRegressor):
 
 
 class QuantileRegression(BaseScipyMinimizeRegressor):
-    """
-    Compute Quantile Regression. This can be used for computing confidence intervals of linear regressions.
+    r"""Compute quantile regression. This can be used for computing confidence intervals of linear regressions.
+
     `QuantileRegression` fits a linear model to minimize a weighted residual sum of absolute deviations between
     the observed targets in the dataset and the targets predicted by the linear approximation, i.e.
-        1 / (2 * n_samples) * switch * ||y - Xw||_1
-        + alpha * l1_ratio * ||w||_1
-        + 0.5 * alpha * (1 - l1_ratio) * ||w||_2 ** 2
-    where switch is a vector with value `quantile` if y - Xw < 0, else `1 - quantile`. The regressor defaults to
-    `LADRegression` for its default value of `quantile=0.5`.
+
+    $$\frac{\text{switch} \cdot ||y - Xw||_1}{2 N} + \alpha \cdot l_1 \cdot ||w||_1
+        + \frac{\alpha}{2} \cdot (1 - l_1) \cdot ||w||^2_2$$
+
+    where
+
+    $$\text{switch} = \begin{cases}
+    \text{quantile} & \text{if } y - Xw < 0 \\
+    1-\text{quantile} & \text{otherwise}
+    \end{cases}$$
+
+    The regressor defaults to `LADRegression` for its default value of `quantile=0.5`.
+
     Compared to linear regression, this approach is robust to outliers.
+
+    !!! info
+        This implementation uses
+        [scipy.optimize.minimize](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
+
     Parameters
     ----------
     alpha : float, default=0.0
         Constant that multiplies the penalty terms.
-
     l1_ratio : float, default=0.0
-        The ElasticNet mixing parameter, with ``0 <= l1_ratio <= 1``. For
-        ``l1_ratio = 0`` the penalty is an L2 penalty. ``For l1_ratio = 1`` it
-        is an L1 penalty.  For ``0 < l1_ratio < 1``, the penalty is a
-        combination of L1 and L2.
+        The ElasticNet mixing parameter, with `0 <= l1_ratio <= 1`:
 
+        - `l1_ratio = 0` is equivalent to an L2 penalty.
+        - `l1_ratio = 1` is equivalent to an L1 penalty.
+        - `0 < l1_ratio < 1` is the combination of L1 and L2.
     fit_intercept : bool, default=True
-        Whether to calculate the intercept for this model. If set
-        to False, no intercept will be used in calculations
+        Whether to calculate the intercept for this model. If set to False, no intercept will be used in calculations
         (i.e. data is expected to be centered).
-
     copy_X : bool, default=True
-        If True, X will be copied; else, it may be overwritten.
-
+        If True, `X` will be copied; else, it may be overwritten.
     positive : bool, default=False
         When set to True, forces the coefficients to be positive.
+    method : Literal["SLSQP", "TNC", "L-BFGS-B"], default="SLSQP"
+        Type of solver to use for optimization.
+    quantile : float, default=0.5
+        The line output by the model will have a share of approximately `quantile` data points under it. It  should
+        be a value between 0 and 1.
 
-    method : str, default="SLSQP"
-        Type of solver. Should be one of "SLSQP", "TNC", "L-BFGS-B".
-
-    quantile : float, between 0 and 1, default=0.5
-        The line output by the model will have a share of approximately `quantile` data points under it.
-        A value of `quantile=1` outputs a line that is above each data point, for example. `quantile=0.5` corresponds to LADRegression.
+        A value of `quantile=1` outputs a line that is above each data point, for example.
+        `quantile=0.5` corresponds to LADRegression.
 
     Attributes
     ----------
     coef_ : np.ndarray of shape (n_features,)
         Estimated coefficients of the model.
     intercept_ : float
-        Independent term in the linear model. Set to 0.0 if fit_intercept = False.
-    Notes
-    -----
-    This implementation uses scipy.optimize.minimize, see
-    https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html.
+        Independent term in the linear model. Set to 0.0 if `fit_intercept = False`.
+    n_features_in_ : int
+        Number of features seen during `fit`.
+
     Examples
     --------
-    >>> import numpy as np
-    >>> np.random.seed(0)
-    >>> X = np.random.randn(100, 4)
-    >>> y = X @ np.array([1, 2, 3, 4])
-    >>> l = QuantileRegression().fit(X, y)
-    >>> l.coef_
-    array([1., 2., 3., 4.])
-    >>> import numpy as np
-    >>> np.random.seed(0)
-    >>> X = np.random.randn(100, 4)
-    >>> y = X @ np.array([-1, 2, -3, 4])
-    >>> l = QuantileRegression(quantile=0.8).fit(X, y)
-    >>> l.coef_
-    array([-1.,  2., -3.,  4.])
+    ```py
+    import numpy as np
+    from sklego.linear_model import QuantileRegression
+
+    np.random.seed(0)
+    X = np.random.randn(100, 4)
+    y = X @ np.array([1, 2, 3, 4])
+
+    model = QuantileRegression().fit(X, y)
+    model.coef_
+    # array([1., 2., 3., 4.])
+
+    y = X @ np.array([-1, 2, -3, 4])
+    model = QuantileRegression(quantile=0.8).fit(X, y)
+    model.coef_
+    # array([-1.,  2., -3.,  4.])
+    ```
     """
 
     def __init__(
@@ -859,25 +1083,18 @@ class QuantileRegression(BaseScipyMinimizeRegressor):
         method="SLSQP",
         quantile=0.5,
     ):
-        """Initialize."""
         super().__init__(alpha, l1_ratio, fit_intercept, copy_X, positive, method)
         self.quantile = quantile
 
     def _get_objective(self, X, y, sample_weight):
         def quantile_loss(params):
             return np.mean(
-                sample_weight
-                * np.where(X @ params < y, self.quantile, 1 - self.quantile)
-                * np.abs(y - X @ params)
+                sample_weight * np.where(X @ params < y, self.quantile, 1 - self.quantile) * np.abs(y - X @ params)
             ) + self._regularized_loss(params)
 
         def grad_quantile_loss(params):
             return (
-                -(
-                    sample_weight
-                    * np.where(X @ params < y, self.quantile, 1 - self.quantile)
-                    * np.sign(y - X @ params)
-                )
+                -(sample_weight * np.where(X @ params < y, self.quantile, 1 - self.quantile) * np.sign(y - X @ params))
                 @ X
                 / X.shape[0]
             ) + self._regularized_grad_loss(params)
@@ -885,19 +1102,26 @@ class QuantileRegression(BaseScipyMinimizeRegressor):
         return quantile_loss, grad_quantile_loss
 
     def fit(self, X, y, sample_weight=None):
-        """
-        Fit the model using the SLSQP algorithm.
+        """Fit the estimator on training data `X` and `y` by minimizing the quantile loss function.
+
         Parameters
         ----------
-        X : np.ndarray of shape (n_samples, n_features)
+        X : array-like of shape (n_samples, n_features)
             The training data.
-        y : np.ndarray, 1-dimensional
+        y : array-like of shape (n_samples,)
             The target values.
-        sample_weight : Optional[np.ndarray], default=None
+        sample_weight : array-like of shape (n_samples,) | None, default=None
             Individual weights for each sample.
+
         Returns
         -------
-        Fitted regressor.
+        self : QuantileRegression
+            The fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            If `quantile` is not between 0 and 1.
         """
         if 0 <= self.quantile <= 1:
             super().fit(X, y, sample_weight)
@@ -908,75 +1132,74 @@ class QuantileRegression(BaseScipyMinimizeRegressor):
 
 
 class LADRegression(QuantileRegression):
-    r"""
-    Least absolute deviation Regression.
+    r"""Least absolute deviation Regression.
 
-    LADRegression fits a linear model to minimize the residual sum of absolute deviations between
-    the observed targets in the dataset, and the targets predicted by the linear approximation, i.e.
+    `LADRegression` fits a linear model to minimize the residual sum of absolute deviations between the observed targets
+    in the dataset, and the targets predicted by the linear approximation, i.e.
 
-    .. math::
-        \frac{1}{N}\|y - Xw \|_1 + \alpha \cdot l_1 \cdot\|w\|_1 + \frac{\alpha}{2} \cdot (1-l_1)\cdot \|w\|_2^2
+    $$\frac{1}{N}\|y - Xw \|_1 + \alpha \cdot l_1 \cdot\|w\|_1 + \frac{\alpha}{2} \cdot (1-l_1)\cdot \|w\|^2_2$$
 
-    Compared to linear regression, this approach is robust to outliers. You can even
-    optimize for the lowest MAPE (Mean Average Percentage Error), if you pass in np.abs(1/y_train) for the
-    sample_weight keyword when fitting the regressor.
+    Compared to linear regression, this approach is robust to outliers. You can even optimize for the lowest MAPE
+    (Mean Average Percentage Error), by providing `sample_weight=np.abs(1/y_train)` when fitting the regressor.
+
+    !!! info
+        This implementation uses
+        [scipy.optimize.minimize](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html).
 
     Parameters
     ----------
     alpha : float, default=0.0
-        Constant that multiplies the penalty terms. Defaults to 1.0.
-
+        Constant that multiplies the penalty terms.
     l1_ratio : float, default=0.0
-        The ElasticNet mixing parameter, with ``0 <= l1_ratio <= 1``. For
-        ``l1_ratio = 0`` the penalty is an L2 penalty. ``For l1_ratio = 1`` it
-        is an L1 penalty.  For ``0 < l1_ratio < 1``, the penalty is a
-        combination of L1 and L2.
+        The ElasticNet mixing parameter, with `0 <= l1_ratio <= 1`:
 
+        - `l1_ratio = 0` is equivalent to an L2 penalty.
+        - `l1_ratio = 1` is equivalent to an L1 penalty.
+        - `0 < l1_ratio < 1` is the combination of L1 and L2.
     fit_intercept : bool, default=True
-        Whether to calculate the intercept for this model. If set
-        to False, no intercept will be used in calculations
+        Whether to calculate the intercept for this model. If set to False, no intercept will be used in calculations
         (i.e. data is expected to be centered).
-
     copy_X : bool, default=True
-        If True, X will be copied; else, it may be overwritten.
-
+        If True, `X` will be copied; else, it may be overwritten.
     positive : bool, default=False
         When set to True, forces the coefficients to be positive.
+    method : Literal["SLSQP", "TNC", "L-BFGS-B"], default="SLSQP"
+        Type of solver to use for optimization.
+    quantile : float, default=0.5
+        The line output by the model will have a share of approximately `quantile` data points under it. It  should
+        be a value between 0 and 1.
 
-    method : str, default="SLSQP"
-        Type of solver. Should be one of "SLSQP", "TNC", "L-BFGS-B".
+        A value of `quantile=1` outputs a line that is above each data point, for example.
+        `quantile=0.5` corresponds to LADRegression.
 
     Attributes
     ----------
-    coef_ : np.array of shape (n_features,)
+    coef_ : np.ndarray of shape (n_features,)
         Estimated coefficients of the model.
-
     intercept_ : float
-        Independent term in the linear model. Set to 0.0 if fit_intercept = False.
-
-    Notes
-    -----
-    This implementation uses scipy.optimize.minimize, see
-    https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html.
+        Independent term in the linear model. Set to 0.0 if `fit_intercept = False`.
+    n_features_in_ : int
+        Number of features seen during `fit`.
 
     Examples
     --------
-    >>> import numpy as np
-    >>> np.random.seed(0)
-    >>> X = np.random.randn(100, 4)
-    >>> y = X @ np.array([1, 2, 3, 4])
-    >>> l = LADRegression().fit(X, y)
-    >>> l.coef_
-    array([1., 2., 3., 4.])
+    ```py
+    import numpy as np
+    from sklego.linear_model import LADRegression
 
-    >>> import numpy as np
-    >>> np.random.seed(0)
-    >>> X = np.random.randn(100, 4)
-    >>> y = X @ np.array([-1, 2, -3, 4])
-    >>> l = LADRegression(positive=True).fit(X, y)
-    >>> l.coef_
-    array([7.39575926e-18, 1.42423304e+00, 2.80467827e-17, 4.29789588e+00])
+    np.random.seed(0)
+    X = np.random.randn(100, 4)
+    y = X @ np.array([1, 2, 3, 4])
 
+    model = LADRegression().fit(X, y)
+    model.coef_
+    # array([1., 2., 3., 4.])
+
+    y = X @ np.array([-1, 2, -3, 4])
+    model = LADRegression(positive=True).fit(X, y)
+    model.coef_
+    # array([7.39575926e-18, 1.42423304e+00, 2.80467827e-17, 4.29789588e+00])
+    ```
     """
 
     def __init__(
@@ -988,7 +1211,4 @@ class LADRegression(QuantileRegression):
         positive=False,
         method="SLSQP",
     ):
-        """Initialize."""
-        super().__init__(
-            alpha, l1_ratio, fit_intercept, copy_X, positive, method, quantile=0.5
-        )
+        super().__init__(alpha, l1_ratio, fit_intercept, copy_X, positive, method, quantile=0.5)

--- a/sklego/meta/_grouped_utils.py
+++ b/sklego/meta/_grouped_utils.py
@@ -10,8 +10,7 @@ from sklego.common import as_list
 
 
 def constant_shrinkage(group_sizes: list, alpha: float) -> np.ndarray:
-    r"""
-    The augmented prediction for each level is the weighted average between its prediction and the augmented
+    r"""The augmented prediction for each level is the weighted average between its prediction and the augmented
     prediction for its parent.
 
     Let $\hat{y}_i$ be the prediction at level $i$, with $i=0$ being the root, than the augmented prediction
@@ -19,10 +18,7 @@ def constant_shrinkage(group_sizes: list, alpha: float) -> np.ndarray:
     """
     return np.array(
         [alpha ** (len(group_sizes) - 1)]
-        + [
-            alpha ** (len(group_sizes) - 1 - i) * (1 - alpha)
-            for i in range(1, len(group_sizes) - 1)
-        ]
+        + [alpha ** (len(group_sizes) - 1 - i) * (1 - alpha) for i in range(1, len(group_sizes) - 1)]
         + [(1 - alpha)]
     )
 
@@ -35,9 +31,7 @@ def relative_shrinkage(group_sizes: list) -> np.ndarray:
 def min_n_obs_shrinkage(group_sizes: list, min_n_obs) -> np.ndarray:
     """Use only the smallest group with a certain amount of observations"""
     if min_n_obs > max(group_sizes):
-        raise ValueError(
-            f"There is no group with size greater than or equal to {min_n_obs}"
-        )
+        raise ValueError(f"There is no group with size greater than or equal to {min_n_obs}")
 
     res = np.zeros(len(group_sizes))
     res[np.argmin(np.array(group_sizes) >= min_n_obs) - 1] = 1
@@ -79,14 +73,10 @@ def _data_format_checks(X, name):
 def _shape_check(X, min_value_cols):
     if min_value_cols > 1:
         if X.ndim == 1 or X.shape[1] < 2:
-            raise ValueError(
-                f"0 feature(s) (shape={X.shape}) while a minimum of {min_value_cols} is required."
-            )
+            raise ValueError(f"0 feature(s) (shape={X.shape}) while a minimum of {min_value_cols} is required.")
     else:
         if X.ndim == 2 and X.shape[1] < 1:
-            raise ValueError(
-                f"0 feature(s) (shape={X.shape}) while a minimum of {min_value_cols} is required."
-            )
+            raise ValueError(f"0 feature(s) (shape={X.shape}) while a minimum of {min_value_cols} is required.")
 
 
 def _check_grouping_columns(X_group, **kwargs) -> pd.DataFrame:

--- a/sklego/meta/decay_estimator.py
+++ b/sklego/meta/decay_estimator.py
@@ -1,47 +1,62 @@
 import numpy as np
 from sklearn import clone
 from sklearn.base import BaseEstimator
-from sklearn.utils.validation import (
-    check_is_fitted,
-    check_X_y,
-    FLOAT_DTYPES,
-)
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
 
 
 class DecayEstimator(BaseEstimator):
-    """
-    Morphs an estimator suchs that the training weights can be
-    adapted to ensure that points that are far away have less weight.
-    Note that it is up to the user to sort the dataset appropriately.
-    This meta estimator will only work for estimators that have a
-    "sample_weights" argument in their `.fit()` method.
+    """Morphs an estimator such that the training weights can be adapted to ensure that points that are far away have
+    less weight.
 
-    The `fit` method computes the weights to pass to the estimator.
+    This meta estimator will only work for estimators that allow a `sample_weights` argument in their `.fit()` method.
+    The meta estimator `.fit()` method computes the weights to pass to the estimator's `.fit()` method.
 
-    .. warning:: By default all the checks on the inputs `X` and `y` are delegated to the wrapped estimator.
+    !!! warning
+        It is up to the user to sort the dataset appropriately.
+
+    !!! warning
+        By default all the checks on the inputs `X` and `y` are delegated to the wrapped estimator.
 
         To change such behaviour, set `check_input` to `True`.
 
-        Remark that if the check is skipped, then `y` should have a `shape` attrbute, which is
+        Remark that if the check is skipped, then `y` should have a `shape` attribute, which is
         used to extract the number of samples in training data, and compute the weights.
 
-    The DecayEstimator will use exponential decay to weight the parameters.
+    !!! info
+        The DecayEstimator will use exponential decay to weight the parameters.
 
-    w_{t-1} = decay * w_{t}
+        $$w_{t-1} = decay * w_{t}$$
+
+    Parameters
+    ----------
+    model : scikit-learn compatible estimator
+        The estimator to be wrapped.
+    decay : float, default=0.999
+        The decay factor to use.
+    decay_func : str, default="exponential"
+        The decay function to use. Currently only exponential decay is supported.
+    check_input : bool, default=False
+        Whether or not to check the input data. If False, the checks are delegated to the wrapped estimator.
+
+    Attributes
+    ----------
+    estimator_ : scikit-learn compatible estimator
+        The fitted estimator.
+    weights_ : array-like of shape (n_samples,)
+        The weights used to train the estimator.
+    classes_ : array-like of shape (n_classes,)
+        The classes labels. Only present if the wrapped estimator is a classifier.
     """
 
-    def __init__(
-        self, model, decay: float = 0.999, decay_func="exponential", check_input=False
-    ):
+    def __init__(self, model, decay: float = 0.999, decay_func="exponential", check_input=False):
         self.model = model
         self.decay = decay
         self.decay_func = decay_func
         self.check_input = check_input
 
     def _is_classifier(self):
-        return any(
-            ["ClassifierMixin" in p.__name__ for p in type(self.model).__bases__]
-        )
+        """Checks if the wrapped estimator is a classifier."""
+        return any(["ClassifierMixin" in p.__name__ for p in type(self.model).__bases__])
 
     @property
     def _estimator_type(self):
@@ -49,18 +64,23 @@ class DecayEstimator(BaseEstimator):
         return self.model._estimator_type
 
     def fit(self, X, y):
-        """
-        Fit the data after adapting the same weight.
+        """Fit the underlying estimator on the training data `X` and `y` using the calculated sample weights.
 
-        :param X: array-like, shape=(n_samples, n_features,) training data.
-        :param y: array-like, shape=(n_samples,) target values.
-        :return: Returns an instance of self.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training data.
+        y : array-like of shape (n_samples,)
+            Target values.
+
+        Returns
+        -------
+        self : DecayEstimator
+            The fitted estimator.
         """
 
         if self.check_input:
-            X, y = check_X_y(
-                X, y, estimator=self, dtype=FLOAT_DTYPES, ensure_min_features=0
-            )
+            X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES, ensure_min_features=0)
 
         self.weights_ = np.cumprod(np.ones(y.shape[0]) * self.decay)[::-1]
         self.estimator_ = clone(self.model)
@@ -68,19 +88,23 @@ class DecayEstimator(BaseEstimator):
             self.estimator_.fit(X, y, sample_weight=self.weights_)
         except TypeError as e:
             if "sample_weight" in str(e):
-                raise TypeError(
-                    f"Model {type(self.model).__name__}.fit() does not have 'sample_weight'"
-                )
+                raise TypeError(f"Model {type(self.model).__name__}.fit() does not have 'sample_weight'")
         if self._is_classifier():
             self.classes_ = self.estimator_.classes_
         return self
 
     def predict(self, X):
-        """
-        Predict new data.
+        """Predict target values for `X` using trained underlying estimator.
 
-        :param X: array-like, shape=(n_samples, n_features,) data to predict.
-        :return: array, shape=(n_samples,) the predicted data
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples,)
+            The predicted values.
         """
         if self._is_classifier():
             check_is_fitted(self, ["classes_"])
@@ -88,4 +112,5 @@ class DecayEstimator(BaseEstimator):
         return self.estimator_.predict(X)
 
     def score(self, X, y):
+        """Alias for `.score()` method of the underlying estimator."""
         return self.estimator_.score(X, y)

--- a/sklego/meta/estimator_transformer.py
+++ b/sklego/meta/estimator_transformer.py
@@ -1,32 +1,55 @@
 from sklearn import clone
-from sklearn.base import (
-    BaseEstimator,
-    TransformerMixin,
-    MetaEstimatorMixin,
-)
-from sklearn.utils.validation import (
-    check_is_fitted,
-    check_X_y,
-    FLOAT_DTYPES,
-)
+from sklearn.base import BaseEstimator, MetaEstimatorMixin, TransformerMixin
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
+
 
 
 class EstimatorTransformer(TransformerMixin, MetaEstimatorMixin, BaseEstimator):
-    """
-    Allows using an estimator such as a model as a transformer in an earlier step of a pipeline
+    """Allow using an estimator as a transformer in an earlier step of a pipeline.
 
-    :param estimator: An instance of the estimator that should be used for the transformation
-    :param predict_func: The function called on the estimator when transforming e.g. (`predict`, `predict_proba`)
-    :param check_input: Whether or not to check the input data. If False, the checks are delegated to the wrapped estimator.
-    """
+    !!! warning
+        By default all the checks on the inputs `X` and `y` are delegated to the wrapped estimator.
 
+        To change such behaviour, set `check_input` to `True`.
+
+    Parameters
+    ----------
+    estimator : scikit-learn compatible estimator
+        The estimator to be applied to the data, used as transformer.
+    predict_func : str, default="predict"
+        The method called on the estimator when transforming e.g. (`"predict"`, `"predict_proba"`).
+    check_input : bool, default=False
+        Whether or not to check the input data. If False, the checks are delegated to the wrapped estimator.
+
+    Attributes
+    ----------
+    estimator_ : scikit-learn compatible estimator
+        The fitted underlying estimator.
+    multi_output_ : bool
+        Whether or not the estimator is multi output.
+    """
     def __init__(self, estimator, predict_func="predict", check_input=False):
         self.estimator = estimator
         self.predict_func = predict_func
         self.check_input = check_input
 
     def fit(self, X, y, **kwargs):
-        """Fits the estimator"""
+        """Fit the underlying estimator on training data `X` and `y`.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training data.
+        y : array-like of shape (n_samples,)
+            Target values.
+        **kwargs : dict
+            Additional keyword arguments passed to the `fit` method of the underlying estimator.
+
+        Returns
+        -------
+        self : EstimatorTransformer
+            The fitted transformer.
+        """
 
         if self.check_input:
             X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES, multi_output=True)
@@ -37,12 +60,20 @@ class EstimatorTransformer(TransformerMixin, MetaEstimatorMixin, BaseEstimator):
         return self
 
     def transform(self, X):
-        """
-        Applies the `predict_func` on the fitted estimator.
+        """Transform the data by applying the `predict_func` of the fitted estimator.
 
-        Returns array of shape `(X.shape[0], )` if estimator is not multi output.
-        For multi output estimators an array of shape `(X.shape[0], y.shape[1])` is returned.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to be transformed.
+
+        Returns
+        -------
+        output : array-like of shape (n_samples,) | (n_samples, n_outputs)
+            The transformed data. Array will be of shape `(X.shape[0], )` if estimator is not multi output.
+            For multi output estimators an array of shape `(X.shape[0], y.shape[1])` is returned.
         """
+        
         check_is_fitted(self, "estimator_")
         output = getattr(self.estimator_, self.predict_func)(X)
         return output if self.multi_output_ else output.reshape(-1, 1)

--- a/sklego/meta/grouped_estimator.py
+++ b/sklego/meta/grouped_estimator.py
@@ -1,4 +1,5 @@
 from deprecated import deprecated
+
 from .grouped_predictor import GroupedPredictor
 
 

--- a/sklego/meta/grouped_transformer.py
+++ b/sklego/meta/grouped_transformer.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-
 from sklearn.base import BaseEstimator, TransformerMixin, clone
 from sklearn.utils.validation import check_is_fitted
 
@@ -8,15 +7,26 @@ from ._grouped_utils import _split_groups_and_values
 
 
 class GroupedTransformer(BaseEstimator, TransformerMixin):
-    """
-    Construct a transformer per data group. Splits data by groups from single or multiple columns
-    and transforms remaining columns using the transformers corresponding to the groups.
+    """Construct a transformer per data group. Splits data by groups from single or multiple columns and transforms
+    remaining columns using the transformers corresponding to the groups.
 
-    :param transformer: the transformer to be applied per group
-    :param groups: the column(s) of the matrix/dataframe to select as a grouping parameter set. If None,
-                   the transformer will be applied to the entire input without grouping
-    :param use_global_model: Whether or not to fall back to a general transformation in case a group
-                             is not found during `.transform()`
+    Parameters
+    ----------
+    transformer : scikit-learn compatible transformer
+        The transformer to be applied per group.
+    groups : int | str | List[int] | List[str] | None
+        The column(s) of the array/dataframe to select as a grouping parameter set. If `None`, the transformer will be
+        applied to the entire input without grouping.
+    use_global_model : bool, default=True
+        Whether or not to fall back to a general transformation in case a group is not found during `.transform()`.
+
+    Attributes
+    ----------
+    transformers_ : scikit-learn compatible transformer | dict[..., scikit-learn compatible transformer]
+        The fitted transformers per group or a single fitted transformer if `groups` is `None`.
+    fallback_ : scikit-learn compatible transformer | None
+        The fitted transformer to fall back to in case a group is not found during `.transform()`. Only present if
+        `use_global_model` is `True`.
     """
 
     _check_kwargs = {"accept_large_sparse": False}
@@ -27,14 +37,28 @@ class GroupedTransformer(BaseEstimator, TransformerMixin):
         self.use_global_model = use_global_model
 
     def __fit_single_group(self, group, X, y=None):
+        """Fit transformer to the given group.
+
+        Parameters
+        ----------
+        group : tuple
+            The group to fit the transformer to.
+        X : array-like of shape (n_samples, n_features)
+            Training data.
+        y : array-like of shape (n_samples,), default=None
+            Target values.
+
+        Returns
+        -------
+        transformer : scikit-learn compatible transformer
+            The fitted transformer for the group.
+        """
         try:
             return clone(self.transformer).fit(X, y)
         except Exception as e:
             raise type(e)(f"Exception for group {group}: {e}")
 
-    def __fit_grouped_transformer(
-        self, X_group: pd.DataFrame, X_value: np.array, y=None
-    ):
+    def __fit_grouped_transformer(self, X_group: pd.DataFrame, X_value: np.ndarray, y=None):
         """Fit a transformer to each group"""
         # Make the groups based on the groups dataframe, use the indices on the values array
         try:
@@ -54,25 +78,36 @@ class GroupedTransformer(BaseEstimator, TransformerMixin):
             }
         else:
             grouped_transformers = {
-                group: self.__fit_single_group(group, X_value[indices, :])
-                for group, indices in group_indices.items()
+                group: self.__fit_single_group(group, X_value[indices, :]) for group, indices in group_indices.items()
             }
 
         return grouped_transformers
 
     def __check_transformer(self):
+        """Check if the supplied transformer has a `transform` method and raise a `ValueError` if not."""
         if not hasattr(self.transformer, "transform"):
-            raise ValueError(
-                "The supplied transformer should have a 'transform' method"
-            )
+            raise ValueError("The supplied transformer should have a 'transform' method")
 
     def fit(self, X, y=None):
-        """
-        Fit the transformers to the groups in X
+        """Fit one transformer for each group of training data `X`.
 
-        :param X: Array-like with at least two columns, of which at least one corresponds to groups defined in init,
-                  and the remaining columns represent the values to transform.
-        :param y: (Optional) target variable
+        Will also learn the groups that exist within the dataset.
+
+        If `use_global_model=True` a fallback transformer will be fitted on the entire dataset in case a group is not
+        found during `.transform()`.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training data. If `groups` is not `None`, X should have at least two columns, of which at least one
+            corresponds to groups defined in `groups`, and the remaining columns represent the values to transform.
+        y : array-like of shape (n_samples,), default=None
+            Target values.
+
+        Returns
+        -------
+        self : GroupedTransformer
+            The fitted transformer.
         """
         self.__check_transformer()
 
@@ -82,9 +117,7 @@ class GroupedTransformer(BaseEstimator, TransformerMixin):
             self.transformers_ = clone(self.transformer).fit(X, y)
             return self
 
-        X_group, X_value = _split_groups_and_values(
-            X, self.groups, **self._check_kwargs
-        )
+        X_group, X_value = _split_groups_and_values(X, self.groups, **self._check_kwargs)
         self.transformers_ = self.__fit_grouped_transformer(X_group, X_value, y)
 
         if self.use_global_model:
@@ -102,13 +135,11 @@ class GroupedTransformer(BaseEstimator, TransformerMixin):
             if self.fallback_:
                 group_transformer = self.fallback_
             else:
-                raise ValueError(
-                    f"Found new group {group} during transform with use_global_model = False"
-                )
+                raise ValueError(f"Found new group {group} during transform with use_global_model = False")
 
         return pd.DataFrame(group_transformer.transform(X)).set_index(index)
 
-    def __transform_groups(self, X_group: pd.DataFrame, X_value: np.array):
+    def __transform_groups(self, X_group: pd.DataFrame, X_value: np.ndarray):
         """Transform all groups"""
         # Reset indices such that they are the same in X_group (reset in __check_grouping_columns),
         # this way we can track the order of the result
@@ -130,18 +161,25 @@ class GroupedTransformer(BaseEstimator, TransformerMixin):
         )
 
     def transform(self, X):
-        """
-        Fit the transformers to the groups in X
+        """Transform new data `X` by transforming on each group. If a group is not found during `.transform()` and
+        `use_global_model=True` the fallback transformer will be used. If `use_global_model=False` a `ValueError` will
+        be raised.
 
-        :param X: Array-like with columns corresponding to the ones in .fit()
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Data to transform.
+
+        Returns
+        -------
+        array-like of shape (n_samples, n_features)
+            Data transformed per group.
         """
         check_is_fitted(self, ["fallback_", "transformers_"])
 
         if self.groups is None:
             return self.transformers_.transform(X)
 
-        X_group, X_value = _split_groups_and_values(
-            X, self.groups, **self._check_kwargs
-        )
+        X_group, X_value = _split_groups_and_values(X, self.groups, **self._check_kwargs)
 
         return self.__transform_groups(X_group, X_value)

--- a/sklego/meta/outlier_classifier.py
+++ b/sklego/meta/outlier_classifier.py
@@ -1,38 +1,66 @@
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.calibration import _SigmoidCalibration
-from sklego.base import OutlierModel
 from sklearn.utils.validation import check_is_fitted, check_X_y
+
+from sklego.base import OutlierModel
 
 
 class OutlierClassifier(BaseEstimator, ClassifierMixin):
-    """
-    Morphs an estimator that performs outlier detection into a classifier.
-    When an outlier is detected it will output 1 and 0 otherwise.
-    This way you can use familiar metrics again and this allows you
-    to consider outlier models as a fraud detector.
+    """Morphs an outlier detection model into a classifier.
+
+    When an outlier is detected it will output 1 and 0 otherwise. This way you can use familiar metrics again and
+    this allows you to consider outlier models as a fraud detector.
+
+    Parameters
+    ----------
+    model : scikit-learn compatible outlier detection model
+        An outlier detection model that will be used for prediction.
+
+    Attributes
+    ----------
+    estimator_ : scikit-learn compatible outlier detection model
+        The fitted underlying outlier detection model.
+    classes_ : array-like of shape (2,)
+        Classes used for prediction (0 or 1)
     """
 
     def __init__(self, model):
         self.model = model
 
     def _is_outlier_model(self):
+        """Check if the underlying model is an outlier detection model."""
         return isinstance(self.model, OutlierModel)
 
     def fit(self, X, y=None):
-        """
-        Fit the data after adapting the same weight.
+        """Fit the underlying estimator to the training data `X` and `y`.
 
-        :param X: array-like, shape=(n_columns, n_samples,) training data.
-        :param y: array-like, shape=(n_samples,) training data.
-        :return: Returns an instance of self.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training data.
+        y : array-like of shape (n_samples,), default=None
+            Target values.
+
+        Returns
+        -------
+        self : OutlierClassifier
+            The fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            - If the underlying model is not an outlier detection model.
+            - If the underlying model does not have a `decision_function` method.
         """
         X, y = check_X_y(X, y, estimator=self)
         if not self._is_outlier_model():
             raise ValueError("Passed model does not detect outliers!")
-        if not hasattr(self.model, 'decision_function'):
-            raise ValueError(f'Passed model {self.model} does not have a `decision_function` '
-                             f'method. This is required for `predict_proba` estimation.')
+        if not hasattr(self.model, "decision_function"):
+            raise ValueError(
+                f"Passed model {self.model} does not have a `decision_function` "
+                f"method. This is required for `predict_proba` estimation."
+            )
         self.estimator_ = self.model.fit(X, y)
         self.classes_ = np.array([0, 1])
 
@@ -43,11 +71,17 @@ class OutlierClassifier(BaseEstimator, ClassifierMixin):
         return self
 
     def predict(self, X):
-        """
-        Predict new data.
+        """Predict new data.
 
-        :param X: array-like, shape=(n_columns, n_samples,) training data.
-        :return: array, shape=(n_samples,) the predicted data
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        np.ndarray of shape (n_samples,)
+            The predicted values. 0 for inliers, 1 for outliers.
         """
         check_is_fitted(self, ["estimator_", "classes_"])
         preds = self.estimator_.predict(X)
@@ -56,11 +90,17 @@ class OutlierClassifier(BaseEstimator, ClassifierMixin):
         return result
 
     def predict_proba(self, X):
-        """
-        Predict probability estimates for new data.
+        """Predict probability estimates for new data.
 
-        :param X: array-like, shape=(n_columns, n_samples,) input data.
-        :return: array, shape=(n_samples,) the predicted data
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        np.ndarray of shape (n_samples,)
+            The predicted probabilities.
         """
         check_is_fitted(self, ["estimator_", "classes_"])
         decision_function_scores = self.estimator_.decision_function(X)

--- a/sklego/meta/outlier_remover.py
+++ b/sklego/meta/outlier_remover.py
@@ -1,25 +1,30 @@
+from deprecated import deprecated
 from sklearn import clone
 from sklearn.base import BaseEstimator
-from sklearn.utils.validation import (
-    check_is_fitted,
-    check_array,
-)
+from sklearn.utils.validation import check_array, check_is_fitted
 
 from sklego.common import TrainOnlyTransformerMixin
-from deprecated import deprecated
 
 
 @deprecated(
     version="0.4.2",
-    reason="Please use `sklego.preprocessing.OutlierRemovers` instead. "
+    reason="Please use `sklego.preprocessing.OutlierRemover` instead. "
     "This object will be removed from the meta submodule in version 0.6.0.",
 )
 class OutlierRemover(TrainOnlyTransformerMixin, BaseEstimator):
-    """
-    Removes outliers (train-time only) using the supplied removal model.
+    """Removes outliers (train-time only) using the supplied removal model.
 
-    :param outlier_detector: must implement `fit` and `predict` methods
-    :param refit: If True, fits the estimator during pipeline.fit().
+    Parameters
+    ----------
+    outlier_detector : object
+        An outlier detector that implements `fit` and `predict` methods.
+    refit : bool, default=True
+        If True, fits the estimator during pipeline.fit(). If False, the estimator is not fitted during pipeline.fit().
+
+    Attributes
+    ----------
+    estimator_ : object
+        The fitted outlier detector.
     """
 
     def __init__(self, outlier_detector, refit=True):
@@ -28,6 +33,20 @@ class OutlierRemover(TrainOnlyTransformerMixin, BaseEstimator):
         self.estimator_ = None
 
     def fit(self, X, y=None):
+        """Fits the estimator, and the outlier detector if `refit` is True.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training data.
+        y : array-like of shape (n_samples,), default=None
+            Target values.
+
+        Returns
+        -------
+        self : OutlierRemover
+            The fitted transformer.
+        """
         self.estimator_ = clone(self.outlier_detector)
         if self.refit:
             super().fit(X, y)
@@ -35,6 +54,18 @@ class OutlierRemover(TrainOnlyTransformerMixin, BaseEstimator):
         return self
 
     def transform_train(self, X):
+        """Removes outliers from `X` using the fitted estimator.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data for which the outliers will be removed.
+
+        Returns
+        -------
+        np.ndarray of shape (n_not_outliers, n_features)
+            The data with the outliers removed, where `n_not_outliers = n_samples - n_outliers`.
+        """
         check_is_fitted(self, "estimator_")
         predictions = self.estimator_.predict(X)
         check_array(predictions, estimator=self.outlier_detector, ensure_2d=False)

--- a/sklego/meta/regression_outlier_detector.py
+++ b/sklego/meta/regression_outlier_detector.py
@@ -1,18 +1,40 @@
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, OutlierMixin
-from sklearn.utils.validation import (
-    check_is_fitted,
-    check_array
-)
+from sklearn.utils.validation import check_array, check_is_fitted
 
 
 class RegressionOutlierDetector(BaseEstimator, OutlierMixin):
+    """Morphs a regression estimator into one that can detect outliers. We will try to predict `column` in X.
+
+    Parameters
+    ----------
+    model : scikit-learn compatible regression model
+        A regression model that will be used for prediction.
+    column : int
+        The index of the target column to predict in the input data.
+    lower : float, default=2.0
+        Lower threshold for outlier detection. The method used for detection depends on the `method` parameter.
+    upper : float, default=2.0
+        Upper threshold for outlier detection. The method used for detection depends on the `method` parameter.
+    method : Literal["sd", "relative", "absolute"], default="sd"
+        The method to use for outlier detection.
+
+        - `"sd"` uses standard deviation
+        - `"relative"` uses relative difference
+        - `"absolute"` uses absolute difference
+
+    Attributes
+    ----------
+    estimator_ : scikit-learn compatible regression model
+        The fitted underlying regression model.
+    sd_ : float
+        The standard deviation of the differences between true and predicted values.
+    idx_ : int
+        The index of the target column in the input data.
     """
-    Morphs a regression model into one that can detect outliers. We will try
-    to predict `column` in X.
-    """
-    def __init__(self, model, column, lower=2, upper=2, method='sd'):
+
+    def __init__(self, model, column, lower=2, upper=2, method="sd"):
         self.model = model
         self.column = column
         self.lower = lower
@@ -20,11 +42,11 @@ class RegressionOutlierDetector(BaseEstimator, OutlierMixin):
         self.method = method
 
     def _is_regression_model(self):
-        return any(
-            ["RegressorMixin" in p.__name__ for p in type(self.model).__bases__]
-        )
+        """Check if the underlying model is a regression model."""
+        return any(["RegressorMixin" in p.__name__ for p in type(self.model).__bases__])
 
     def _handle_thresholds(self, y_true, y_pred):
+        """Compute if a sample is an outlier based on the `method` parameter."""
         difference = y_true - y_pred
         results = np.ones(difference.shape, dtype=int)
         allowed_methods = ["sd", "relative", "absolute"]
@@ -34,8 +56,8 @@ class RegressionOutlierDetector(BaseEstimator, OutlierMixin):
             lower_limit_hit = -self.lower * self.sd_ > difference
             upper_limit_hit = self.upper * self.sd_ < difference
         if self.method == "relative":
-            lower_limit_hit = -self.lower > difference/y_true
-            upper_limit_hit = self.upper < difference/y_true
+            lower_limit_hit = -self.lower > difference / y_true
+            upper_limit_hit = self.upper < difference / y_true
         if self.method == "absolute":
             lower_limit_hit = -self.lower > difference
             upper_limit_hit = self.upper < difference
@@ -44,6 +66,22 @@ class RegressionOutlierDetector(BaseEstimator, OutlierMixin):
         return results
 
     def to_x_y(self, X):
+        """Split `X` into two arrays `X_to_use` and `y`.
+        `y` is the column we want to predict (specified in the `column` parameter) and `X_to_use` is the rest of the
+        data.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Data to split.
+
+        Returns
+        -------
+        X_to_use : array-like of shape (n_samples, n_features-1)
+            Data to use for prediction.
+        y : array-like of shape (n_samples,)
+            The target column.
+        """
         y = X[:, self.idx_]
         cols_to_use = [i for i in range(X.shape[1]) if i != self.column]
         X_to_use = X[:, cols_to_use]
@@ -52,12 +90,27 @@ class RegressionOutlierDetector(BaseEstimator, OutlierMixin):
         return X_to_use, y
 
     def fit(self, X, y=None):
-        """
-        Fit the data after adapting the same weight.
+        """Fit the underlying model on `X_to_use` and `y` where:
 
-        :param X: array-like, shape=(n_columns, n_samples,) training data.
-        :param y: array-like, shape=(n_samples,) training data.
-        :return: Returns an instance of self.
+        - `y` is the column we want to predict (`X[:, self.column]`)
+        - `X_to_use` is the rest of the data.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training data.
+        y : array-like of shape (n_samples,), default=None
+            Ignored, present for compatibility.
+
+        Returns
+        -------
+        self : RegressionOutlierDetector
+            The fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            If the `model` is not a regression estimator.
         """
         self.idx_ = np.argmax([i == self.column for i in X.columns]) if isinstance(X, pd.DataFrame) else self.column
         X = check_array(X, estimator=self)
@@ -69,20 +122,47 @@ class RegressionOutlierDetector(BaseEstimator, OutlierMixin):
         return self
 
     def predict(self, X, y=None):
-        """
-        Predict new data.
+        """Predict which samples of `X` are outliers using the underlying estimator and given `method`.
 
-        :param X: array-like, shape=(n_columns, n_samples,) training data.
-        :return: array, shape=(n_samples,) the predicted data
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+        y : array-like of shape (n_samples,), default=None
+            Ignored, present for compatibility.
+
+        Returns
+        -------
+        np.ndarray of shape (n_samples,)
+            The predicted values. 1 for inliers, -1 for outliers.
         """
-        check_is_fitted(self, ['estimator_', 'sd_', 'idx_'])
+        check_is_fitted(self, ["estimator_", "sd_", "idx_"])
         X = check_array(X, estimator=self)
         X, y = self.to_x_y(X)
         preds = self.estimator_.predict(X)
         return self._handle_thresholds(y, preds)
 
     def score_samples(self, X, y=None):
-        check_is_fitted(self, ['estimator_', 'sd_', 'idx_'])
+        """Calculate the outlier scores for the given data.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Data for which outlier scores are calculated.
+        y : array-like of shape shape=(n_samples,), default=None
+            Ignored, present for compatibility.
+
+        Returns
+        -------
+        np.ndarray of shape (n_samples,)
+            The outlier scores for the input data.
+
+        Raises
+        ------
+        ValueError
+            If `method` is not one of "sd", "relative", or "absolute".
+        """
+        check_is_fitted(self, ["estimator_", "sd_", "idx_"])
         X = check_array(X, estimator=self)
         X, y_true = self.to_x_y(X)
         y_pred = self.estimator_.predict(X)
@@ -93,6 +173,6 @@ class RegressionOutlierDetector(BaseEstimator, OutlierMixin):
         if self.method == "sd":
             return difference
         if self.method == "relative":
-            return difference/y_true
+            return difference / y_true
         if self.method == "absolute":
             return difference

--- a/sklego/meta/thresholder.py
+++ b/sklego/meta/thresholder.py
@@ -1,27 +1,36 @@
 import numpy as np
 from sklearn import clone
-from sklearn.base import (
-    BaseEstimator,
-    ClassifierMixin,
-)
-from sklearn.utils.validation import (
-    check_is_fitted
-)
+from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.exceptions import NotFittedError
+from sklearn.utils.validation import check_is_fitted
 
 from sklego.base import ProbabilisticClassifier
 
 
 class Thresholder(BaseEstimator, ClassifierMixin):
-    """
-    Takes a two class estimator and moves the threshold. This way you might
-    design the algorithm to only accept a certain class if the probability
-    for it is larger than, say, 90% instead of 50%.
+    """Takes a binary classifier and moves the threshold. This way you might design the algorithm to only accept a
+    certain class if the probability for it is larger than, say, 90% instead of 50%.
 
-    :param model: the model to threshold
-    :param threshold: the actual threshold to use
-    :param refit: if True, we will always retrain the model even if it is already fitted.
-    If False we only refit if the original model isn't fitted.
+    !!! info
+        Please note that this only works for binary classification problems.
+
+    Parameters
+    ----------
+    model : scikit-learn compatible classifier
+        Classifier that will be wrapped with Thresholder. It should implement `predict_proba` method.
+    threshold : float
+        The threshold value to use.
+    refit : bool, default=False
+
+        - If True, we will always retrain the model even if it is already fitted.
+        - If False we only refit if the original model isn't fitted.
+
+    Attributes
+    ----------
+    estimator_ : scikit-learn compatible classifier
+        The fitted classifier.
+    classes_ : array-like, shape=(2,)
+        The classes labels.
     """
 
     def __init__(self, model, threshold: float, refit=False):
@@ -30,7 +39,7 @@ class Thresholder(BaseEstimator, ClassifierMixin):
         self.refit = refit
 
     def _handle_refit(self, X, y, sample_weight=None):
-        """Only refit when we need to, unless refit=True is present."""
+        """Only refit when we need to, unless `refit=True` is present."""
         if self.refit:
             self.estimator_ = clone(self.model)
             self.estimator_.fit(X, y, sample_weight=sample_weight)
@@ -41,41 +50,60 @@ class Thresholder(BaseEstimator, ClassifierMixin):
                 self.estimator_.fit(X, y, sample_weight=sample_weight)
 
     def fit(self, X, y, sample_weight=None):
-        """
-        Fit the data.
+        """Fit the underlying estimator using `X` and `y` as training data. If `refit=True` we will always retrain
+        (a copy of) the estimator.
 
-        :param X: array-like, shape=(n_columns, n_samples,) training data.
-        :param y: array-like, shape=(n_samples,) training data.
-        :param sample_weight: array-like, shape=(n_samples) Individual weights for each sample.
-        :return: Returns an instance of self.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features )
+            The training data.
+        y : array-like of shape (n_samples,)
+            The target values.
+        sample_weight : array-like of shape (n_samples, ), default=None
+            Individual weights for each sample.
+
+        Returns
+        -------
+        self : Thresholder
+            The fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            - If `model` is not a classifier or it does not implement `predict_proba` method.
+            - If `model` does not have two classes.
         """
         self.estimator_ = self.model
         if not isinstance(self.estimator_, ProbabilisticClassifier):
-            raise ValueError(
-                "The Thresholder meta model only works on classification models with .predict_proba."
-            )
+            raise ValueError("The Thresholder meta model only works on classification models with .predict_proba.")
         self._handle_refit(X, y, sample_weight)
         self.classes_ = self.estimator_.classes_
         if len(self.classes_) != 2:
-            raise ValueError(
-                "The Thresholder meta model only works on models with two classes."
-            )
+            raise ValueError("The `Thresholder` meta model only works on models with two classes.")
         return self
 
     def predict(self, X):
-        """
-        Predict new data.
+        """Predict target values for `X` using fitted estimator and the given `threshold`.
 
-        :param X: array-like, shape=(n_columns, n_samples,) training data.
-        :return: array, shape=(n_samples,) the predicted data
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples,)
+            The predicted values.
         """
         check_is_fitted(self, ["classes_", "estimator_"])
         predicate = self.estimator_.predict_proba(X)[:, 1] > self.threshold
         return np.where(predicate, self.classes_[1], self.classes_[0])
 
     def predict_proba(self, X):
+        """Alias for `.predict_proba()` method of the underlying estimator."""
         check_is_fitted(self, ["classes_", "estimator_"])
         return self.estimator_.predict_proba(X)
 
     def score(self, X, y):
+        """Alias for `.score()` method of the underlying estimator."""
         return self.estimator_.score(X, y)

--- a/sklego/mixture/__init__.py
+++ b/sklego/mixture/__init__.py
@@ -1,11 +1,6 @@
-__all__ = [
-    "GMMClassifier",
-    "BayesianGMMClassifier",
-    "GMMOutlierDetector",
-    "BayesianGMMOutlierDetector"
-]
+__all__ = ["GMMClassifier", "BayesianGMMClassifier", "GMMOutlierDetector", "BayesianGMMOutlierDetector"]
 
-from .gmm_classifier import GMMClassifier
 from .bayesian_gmm_classifier import BayesianGMMClassifier
-from .gmm_outlier_detector import GMMOutlierDetector
 from .bayesian_gmm_detector import BayesianGMMOutlierDetector
+from .gmm_classifier import GMMClassifier
+from .gmm_outlier_detector import GMMOutlierDetector

--- a/sklego/mixture/bayesian_gmm_classifier.py
+++ b/sklego/mixture/bayesian_gmm_classifier.py
@@ -4,10 +4,26 @@ from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.mixture import BayesianGaussianMixture
 from sklearn.utils import check_X_y
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import check_is_fitted, check_array, FLOAT_DTYPES
+from sklearn.utils.validation import FLOAT_DTYPES, check_array, check_is_fitted
 
 
 class BayesianGMMClassifier(BaseEstimator, ClassifierMixin):
+    """The `BayesianGMMClassifier` trains a Gaussian Mixture Model for each class in `y` on a dataset `X`.
+    Once a density is trained for each class we can evaluate the likelihood scores to see which class is more likely.
+
+    !!! note
+        All the parameters are an exact copy of those of
+        [sklearn.mixture.BayesianGaussianMixture]( https://scikit-learn.org/stable/modules/generated/sklearn.mixture.BayesianGaussianMixture.html).
+
+
+    Attributes
+    ----------
+    gmms_ : dict[int, BayesianGaussianMixture]
+        A dictionary of Bayesian Gaussian Mixture Models, one for each class.
+    classes_ : np.ndarray of shape (n_classes,)
+        The classes seen during `fit`.
+    """
+
     def __init__(
         self,
         n_components=1,
@@ -28,11 +44,6 @@ class BayesianGMMClassifier(BaseEstimator, ClassifierMixin):
         verbose=0,
         verbose_interval=10,
     ):
-        """
-        The BayesianGMMClassifier trains a Gaussian Mixture Model for each class in y on a dataset X. Once
-        a density is trained for each class we can evaluate the likelihood scores to see which class
-        is more likely. All parameters of the model are an exact copy of the parameters in scikit-learn.
-        """
         self.n_components = n_components
         self.covariance_type = covariance_type
         self.tol = tol
@@ -51,13 +62,20 @@ class BayesianGMMClassifier(BaseEstimator, ClassifierMixin):
         self.verbose = verbose
         self.verbose_interval = verbose_interval
 
-    def fit(self, X: np.array, y: np.array) -> "BayesianGMMClassifier":
-        """
-        Fit the model using X, y as training data.
+    def fit(self, X: np.ndarray, y: np.ndarray) -> "BayesianGMMClassifier":
+        """Fit the `BayesianGMMClassifier` model using `X`, `y` as training data.
 
-        :param X: array-like, shape=(n_columns, n_samples, ) training data.
-        :param y: array-like, shape=(n_samples, ) training data.
-        :return: Returns an instance of self.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features )
+            The training data.
+        y : array-like of shape (n_samples,)
+            The target values.
+
+        Returns
+        -------
+        self : BayesianGMMClassifier
+            The fitted estimator.
         """
         X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         if X.ndim == 1:
@@ -90,11 +108,35 @@ class BayesianGMMClassifier(BaseEstimator, ClassifierMixin):
         return self
 
     def predict(self, X):
+        """Predict labels for `X` using fitted estimator.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples,)
+            The predicted data.
+        """
         check_is_fitted(self, ["gmms_", "classes_"])
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         return self.classes_[self.predict_proba(X).argmax(axis=1)]
 
     def predict_proba(self, X):
+        """Predict probabilities for `X` using fitted estimator.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples, n_classes)
+            The predicted probabilities.
+        """
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         check_is_fitted(self, ["gmms_", "classes_"])
         res = np.zeros((X.shape[0], self.classes_.shape[0]))

--- a/sklego/mixture/bayesian_gmm_detector.py
+++ b/sklego/mixture/bayesian_gmm_detector.py
@@ -1,32 +1,41 @@
 import numpy as np
 from scipy.optimize import minimize_scalar
+from scipy.stats import gaussian_kde
 from sklearn.base import BaseEstimator, OutlierMixin
 from sklearn.mixture import BayesianGaussianMixture
-from sklearn.utils.validation import check_is_fitted, check_array, FLOAT_DTYPES
-
-from scipy.stats import gaussian_kde
+from sklearn.utils.validation import FLOAT_DTYPES, check_array, check_is_fitted
 
 
 class BayesianGMMOutlierDetector(OutlierMixin, BaseEstimator):
-    """
-    The GMMDetector trains a Bayesian Gaussian Mixture Model on a dataset X. Once
-    a density is trained we can evaluate the likelihood scores to see if
-    it is deemed likely. By giving a threshold this model might then label
-    outliers if their likelihood score is too low.
+    """The `BayesianGMMOutlierDetector` trains a Bayesian Gaussian Mixture model on a dataset `X`. Once a density is
+    trained we can evaluate the likelihood scores to see if it is deemed likely.
 
-    :param threshold: the limit at which the model thinks an outlier appears, must be between (0, 1)
-    :param method: the method that the threshold will be applied to, possible values = [stddev, default=quantile]
+    By giving a threshold this model might then label outliers if their likelihood score is too low.
 
-    If you select method="quantile" then the threshold value represents the
-    quantile value to start calling something an outlier.
+    Parameters
+    ----------
+    threshold : float, default=0.99
+        The limit at which the model thinks an outlier appears, must be between (0, 1).
+    method : Literal["quantile", "stddev"], default="quantile"
+        The method to use to apply the `threshold`.
 
-    If you select method="stddev" then the threshold value represents the
-    numbers of standard deviations before calling something an outlier.
+        !!! info
+            If you select `method="quantile"` then the threshold value represents the quantile value to start calling
+            something an outlier.
 
-    There are other settings too, these are best described in the BayesianGaussianMixture
-    documentation found here:
+            If you select `method="stddev"` then the threshold value represents the
+            numbers of standard deviations before calling something an outlier.
 
-    https://scikit-learn.org/stable/modules/generated/sklearn.mixture.BayesianGaussianMixture.html.
+    !!! note
+        The other parameters are an exact copy of the parameters in
+        [sklearn.mixture.BayesianGaussianMixture]( https://scikit-learn.org/stable/modules/generated/sklearn.mixture.BayesianGaussianMixture.html).
+
+    Attributes
+    ----------
+    gmm_ : BayesianGaussianMixture
+        The trained Bayesian Gaussian Mixture Model.
+    likelihood_threshold_ : float
+        The threshold value used to determine if something is an outlier.
     """
 
     def __init__(
@@ -73,13 +82,27 @@ class BayesianGMMOutlierDetector(OutlierMixin, BaseEstimator):
         self.verbose = verbose
         self.verbose_interval = verbose_interval
 
-    def fit(self, X: np.array, y=None) -> "BayesianGMMOutlierDetector":
-        """
-        Fit the model using X, y as training data.
+    def fit(self, X: np.ndarray, y=None) -> "BayesianGMMOutlierDetector":
+        """Fit the `BayesianGMMOutlierDetector` model using `X`, `y` as training data.
 
-        :param X: array-like, shape=(n_columns, n_samples,) training data.
-        :param y: ignored but kept in for pipeline support
-        :return: Returns an instance of self.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features )
+            The training data.
+        y : array-like of shape (n_samples,)
+            Ignored, present for compatibility.
+
+        Returns
+        -------
+        self : BayesianGMMOutlierDetector
+            The fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            - If `method="quantile"` and `threshold` is not between (0, 1).
+            - If `method="stddev"` and `threshold` is negative.
+            - If `method` is not in `["quantile", "stddev"]`.
         """
 
         # GMM sometimes throws an error if you don't do this
@@ -87,20 +110,12 @@ class BayesianGMMOutlierDetector(OutlierMixin, BaseEstimator):
         if len(X.shape) == 1:
             X = np.expand_dims(X, 1)
 
-        if (self.method == "quantile") and (
-            (self.threshold > 1) or (self.threshold < 0)
-        ):
-            raise ValueError(
-                f"Threshold {self.threshold} with method {self.method} needs to be 0 < threshold < 1"
-            )
+        if (self.method == "quantile") and ((self.threshold > 1) or (self.threshold < 0)):
+            raise ValueError(f"Threshold {self.threshold} with method {self.method} needs to be 0 < threshold < 1")
         if (self.method == "stddev") and (self.threshold < 0):
-            raise ValueError(
-                f"Threshold {self.threshold} with method {self.method} needs to be 0 < threshold "
-            )
+            raise ValueError(f"Threshold {self.threshold} with method {self.method} needs to be 0 < threshold ")
         if self.method not in self.allowed_methods:
-            raise ValueError(
-                f"Method not recognised. Method must be in {self.allowed_methods}"
-            )
+            raise ValueError(f"Method not recognised. Method must be in {self.allowed_methods}")
 
         self.gmm_ = BayesianGaussianMixture(
             n_components=self.n_components,
@@ -133,13 +148,12 @@ class BayesianGMMOutlierDetector(OutlierMixin, BaseEstimator):
             mean_likelihood = score_samples.mean()
             new_likelihoods = score_samples[score_samples < max_x_value]
             new_likelihoods_std = np.std(new_likelihoods - mean_likelihood)
-            self.likelihood_threshold_ = mean_likelihood - (
-                self.threshold * new_likelihoods_std
-            )
+            self.likelihood_threshold_ = mean_likelihood - (self.threshold * new_likelihoods_std)
 
         return self
 
     def score_samples(self, X):
+        """Compute the log likelihood for each sample and return the negative value."""
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         check_is_fitted(self, ["gmm_", "likelihood_threshold_"])
         if len(X.shape) == 1:
@@ -152,10 +166,17 @@ class BayesianGMMOutlierDetector(OutlierMixin, BaseEstimator):
         return self.score_samples(X) + self.likelihood_threshold_
 
     def predict(self, X):
-        """
-        Predict if a point is an outlier.
-        :param X: array-like, shape=(n_columns, n_samples, ) training data.
-        :return: array, shape=(n_samples,) the predicted data. 1 for inliers, -1 for outliers.
+        """Predict if a point is an outlier or not using the fitted estimator.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples,)
+            The predicted data. 1 for inliers, -1 for outliers.
         """
         predictions = (self.decision_function(X) >= 0).astype(int)
         predictions[predictions == 1] = -1

--- a/sklego/mixture/gmm_classifier.py
+++ b/sklego/mixture/gmm_classifier.py
@@ -4,10 +4,27 @@ from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.mixture import GaussianMixture
 from sklearn.utils import check_X_y
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import check_is_fitted, check_array, FLOAT_DTYPES
+from sklearn.utils.validation import FLOAT_DTYPES, check_array, check_is_fitted
 
 
 class GMMClassifier(BaseEstimator, ClassifierMixin):
+    """The `GMMClassifier` trains a Gaussian Mixture Model for each class in `y` on a dataset `X`. Once a density is
+    trained for each class we can evaluate the likelihood scores to see which class is more likely.
+
+    All parameters of the model are an exact copy of the parameters in scikit-learn.
+
+    !!! note
+        All the parameters are an exact copy of those of
+        [sklearn.mixture.GaussianMixture]( https://scikit-learn.org/stable/modules/generated/sklearn.mixture.GaussianMixture.html).
+
+    Attributes
+    ----------
+    gmms_ : dict[int, GaussianMixture]
+        A dictionary of Gaussian Mixture Models, one for each class.
+    classes_ : np.ndarray of shape (n_classes,)
+        The classes seen during `fit`.
+    """
+
     def __init__(
         self,
         n_components=1,
@@ -25,11 +42,6 @@ class GMMClassifier(BaseEstimator, ClassifierMixin):
         verbose=0,
         verbose_interval=10,
     ):
-        """
-        The GMMClassifier trains a Gaussian Mixture Model for each class in y on a dataset X. Once
-        a density is trained for each class we can evaluate the likelihood scores to see which class
-        is more likely. All parameters of the model are an exact copy of the parameters in scikit-learn.
-        """
         self.n_components = n_components
         self.covariance_type = covariance_type
         self.tol = tol
@@ -45,13 +57,20 @@ class GMMClassifier(BaseEstimator, ClassifierMixin):
         self.verbose = verbose
         self.verbose_interval = verbose_interval
 
-    def fit(self, X: np.array, y: np.array) -> "GMMClassifier":
-        """
-        Fit the model using X, y as training data.
+    def fit(self, X: np.ndarray, y: np.ndarray) -> "GMMClassifier":
+        """Fit the `GMMClassifier` model using `X`, `y` as training data.
 
-        :param X: array-like, shape=(n_columns, n_samples, ) training data.
-        :param y: array-like, shape=(n_samples, ) training data.
-        :return: Returns an instance of self.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features )
+            The training data.
+        y : array-like of shape (n_samples,)
+            The target values.
+
+        Returns
+        -------
+        self : GMMClassifier
+            The fitted estimator.
         """
         X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         if X.ndim == 1:
@@ -81,11 +100,35 @@ class GMMClassifier(BaseEstimator, ClassifierMixin):
         return self
 
     def predict(self, X):
+        """Predict labels for `X` using fitted estimator.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples,)
+            The predicted data.
+        """
         check_is_fitted(self, ["gmms_", "classes_"])
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         return self.classes_[self.predict_proba(X).argmax(axis=1)]
 
     def predict_proba(self, X):
+        """Predict probabilities for `X` using fitted estimator.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples, n_classes)
+            The predicted probabilities.
+        """
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         check_is_fitted(self, ["gmms_", "classes_"])
         res = np.zeros((X.shape[0], self.classes_.shape[0]))

--- a/sklego/mixture/gmm_outlier_detector.py
+++ b/sklego/mixture/gmm_outlier_detector.py
@@ -1,27 +1,41 @@
 import numpy as np
 from scipy.optimize import minimize_scalar
+from scipy.stats import gaussian_kde
 from sklearn.base import BaseEstimator, OutlierMixin
 from sklearn.mixture import GaussianMixture
-from sklearn.utils.validation import check_is_fitted, check_array, FLOAT_DTYPES
-
-from scipy.stats import gaussian_kde
+from sklearn.utils.validation import FLOAT_DTYPES, check_array, check_is_fitted
 
 
 class GMMOutlierDetector(OutlierMixin, BaseEstimator):
-    """
-    The GMMDetector trains a Gaussian Mixture Model on a dataset X. Once
-    a density is trained we can evaluate the likelihood scores to see if
-    it is deemed likely. By giving a threshold this model might then label
-    outliers if their likelihood score is too low.
+    """The `GMMDetector` trains a Gaussian Mixture model on a dataset `X`. Once a density is trained we can evaluate the
+    likelihood scores to see if it is deemed likely.
 
-    :param threshold: the limit at which the model thinks an outlier appears, must be between (0, 1)
-    :param method: the method that the threshold will be applied to, possible values = [stddev, default=quantile]
+    By giving a threshold this model might then label outliers if their likelihood score is too low.
 
-    If you select method="quantile" then the threshold value represents the
-    quantile value to start calling something an outlier.
+    Parameters
+    ----------
+    threshold : float, default=0.99
+        The limit at which the model thinks an outlier appears, must be between (0, 1).
+    method : Literal["quantile", "stddev"], default="quantile"
+        The method to use to apply the `threshold`.
 
-    If you select method="stddev" then the threshold value represents the
-    numbers of standard deviations before calling something an outlier.
+        !!! info
+            If you select `method="quantile"` then the threshold value represents the quantile value to start calling
+            something an outlier.
+
+            If you select `method="stddev"` then the threshold value represents the
+            numbers of standard deviations before calling something an outlier.
+
+    !!! note
+        The other parameters are an exact copy of the parameters in
+        [sklearn.mixture.GaussianMixture]( https://scikit-learn.org/stable/modules/generated/sklearn.mixture.GaussianMixture.html).
+
+    Attributes
+    ----------
+    gmm_ : GaussianMixture
+        The trained Gaussian Mixture model.
+    likelihood_threshold_ : float
+        The threshold value used to determine if something is an outlier.
     """
 
     def __init__(
@@ -62,34 +76,39 @@ class GMMOutlierDetector(OutlierMixin, BaseEstimator):
         self.verbose = verbose
         self.verbose_interval = verbose_interval
 
-    def fit(self, X: np.array, y=None) -> "GMMOutlierDetector":
-        """
-        Fit the model using X, y as training data.
+    def fit(self, X: np.ndarray, y=None) -> "GMMOutlierDetector":
+        """Fit the `BayesianGMMOutlierDetector` model using `X`, `y` as training data.
 
-        :param X: array-like, shape=(n_columns, n_samples,) training data.
-        :param y: ignored but kept in for pipeline support
-        :return: Returns an instance of self.
-        """
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features )
+            The training data.
+        y : array-like of shape (n_samples,)
+            Ignored, present for compatibility.
 
+        Returns
+        -------
+        self : GMMOutlierDetector
+            The fitted estimator.
+
+        Raises
+        ------
+        ValueError
+            - If `method="quantile"` and `threshold` is not between (0, 1).
+            - If `method="stddev"` and `threshold` is negative.
+            - If `method` is not in `["quantile", "stddev"]`.
+        """
         # GMM sometimes throws an error if you don't do this
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         if len(X.shape) == 1:
             X = np.expand_dims(X, 1)
 
-        if (self.method == "quantile") and (
-            (self.threshold > 1) or (self.threshold < 0)
-        ):
-            raise ValueError(
-                f"Threshold {self.threshold} with method {self.method} needs to be 0 < threshold < 1"
-            )
+        if (self.method == "quantile") and ((self.threshold > 1) or (self.threshold < 0)):
+            raise ValueError(f"Threshold {self.threshold} with method {self.method} needs to be 0 < threshold < 1")
         if (self.method == "stddev") and (self.threshold < 0):
-            raise ValueError(
-                f"Threshold {self.threshold} with method {self.method} needs to be 0 < threshold "
-            )
+            raise ValueError(f"Threshold {self.threshold} with method {self.method} needs to be 0 < threshold ")
         if self.method not in self.allowed_methods:
-            raise ValueError(
-                f"Method not recognised. Method must be in {self.allowed_methods}"
-            )
+            raise ValueError(f"Method not recognised. Method must be in {self.allowed_methods}")
 
         self.gmm_ = GaussianMixture(
             n_components=self.n_components,
@@ -119,13 +138,12 @@ class GMMOutlierDetector(OutlierMixin, BaseEstimator):
             mean_likelihood = score_samples.mean()
             new_likelihoods = score_samples[score_samples < max_x_value]
             new_likelihoods_std = np.std(new_likelihoods - mean_likelihood)
-            self.likelihood_threshold_ = mean_likelihood - (
-                self.threshold * new_likelihoods_std
-            )
+            self.likelihood_threshold_ = mean_likelihood - (self.threshold * new_likelihoods_std)
 
         return self
 
     def score_samples(self, X):
+        """Compute the log likelihood for each sample and return the negative value."""
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         check_is_fitted(self, ["gmm_", "likelihood_threshold_"])
         if len(X.shape) == 1:
@@ -138,11 +156,17 @@ class GMMOutlierDetector(OutlierMixin, BaseEstimator):
         return self.score_samples(X) + self.likelihood_threshold_
 
     def predict(self, X):
-        """
-        Predict if a point is an outlier.
+        """Predict if a point is an outlier or not using the fitted model.
 
-        :param X: array-like, shape=(n_columns, n_samples, ) training data.
-        :return: array, shape=(n_samples,) the predicted data. 1 for inliers, -1 for outliers.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples,)
+            The predicted data. 1 for inliers, -1 for outliers.
         """
         predictions = (self.decision_function(X) >= 0).astype(int)
         predictions[predictions == 1] = -1

--- a/sklego/model_selection.py
+++ b/sklego/model_selection.py
@@ -14,17 +14,16 @@ from sklego.common import sliding_window
 
 
 class TimeGapSplit:
-    """
-    Provides train/test indices to split time series data samples.
-    This cross-validation object is a variation of TimeSeriesSplit with the following 
-    differences:
+    r"""Provides train/test indices to split time series data samples.
+
+    This cross-validation object is a variation of TimeSeriesSplit with the following  differences:
 
     - The splits are made based on datetime duration, instead of number of rows.
     - The user specifies the validation durations and either training_duration or n_splits.
     - The user can specify a 'gap' duration that is added after the training split and before the validation split.
 
-    The 3 duration parameters can be used to really replicate how the model is going to
-    be used in production in batch learning.
+    The 3 duration parameters can be used to really replicate how the model is going to be used in production in batch
+    learning.
 
     Each validation fold doesn't overlap. The entire 'window' moves by 1 'valid_duration'
     until there is not enough data.
@@ -42,18 +41,29 @@ class TimeGapSplit:
 
     such that the shifting the entire window by one validation duration spans the whole training set.
 
-    :param pandas.Series date_serie: series with the date, that should have all the indices of X used in the split() method.
-    :param datetime.timedelta train_duration: historical training data.
-    :param datetime.timedelta valid_duration: retraining period.
-    :param datetime.timedelta gap_duration: forward looking window of the target.
-        The period of the forward looking window necessary to create your target variable.
+    Parameters
+    ----------
+    date_serie : pd.Series
+        Series with the date, that should have all the indices of X used in the split() method.
+    valid_duration : datetime.timedelta
+        Retraining period.
+    train_duration : datetime.timedelta | None, default=None
+        Historical training data.
+    gap_duration : datetime.timedelta, default=timedelta(0)
+        Forward looking window of the target. The period of the forward looking window necessary to create your target
+        variable.
+
         This period is dropped at the end of your training folds due to lack of recent data.
+
         In production you would have not been able to create the target for that period, and you would have drop it from
         the training data.
-    :param int n_splits: number of splits.
-    :param string window: either 'rolling' or 'expanding'.
-        'rolling' window has fixed size and is shifted entirely.
-        'expanding' left side of window is fixed, right border increases each fold.
+    n_splits : int | None, default=None
+        Number of splits.
+    window : Literal["rolling", "expanding"], default="rolling"
+        Type of moving window to use.
+
+        - `"rolling"` window has fixed size and is shifted entirely.
+        - `"expanding"` left side of window is fixed, right border increases each fold.
     """
 
     def __init__(
@@ -69,9 +79,7 @@ class TimeGapSplit:
             raise ValueError("Either train_duration or n_splits have to be defined")
 
         if (train_duration is not None) and (train_duration <= gap_duration):
-            raise ValueError(
-                "gap_duration is longer than train_duration, it should be shorter."
-            )
+            raise ValueError("gap_duration is longer than train_duration, it should be shorter.")
 
         if not date_serie.index.is_unique:
             raise ValueError("date_serie doesn't have a unique index")
@@ -85,11 +93,14 @@ class TimeGapSplit:
         self.window = window
 
     def _join_date_and_x(self, X):
-        """
-        Make a DataFrame indexed by the pandas index (the same as date_series) with date column joined with that index
-        and with the 'numpy index' column (i.e. just a range) that is required for the output and the rest of sklearn.
+        """Creates a DataFrame indexed by the pandas index (the same as `date_serie`) with date column joined with that
+        index and with the 'numpy index' column (i.e. just a range) that is required for the output and the rest of
+        sklearn.
 
-        :param pandas.DataFrame X: Dataframe with the data to split
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Dataframe with the data to split
         """
         X_index_df = pd.DataFrame(range(len(X)), columns=["np_index"], index=X.index)
         X_index_df = X_index_df.join(self.date_serie)
@@ -97,12 +108,21 @@ class TimeGapSplit:
         return X_index_df
 
     def split(self, X, y=None, groups=None):
-        """
-        Generate indices to split data into training and test set.
+        """Generate indices to split data into training and test set.
 
-        :param pandas.DataFrame X: Dataframe with the data to split
-        :param y: Always ignored, exists for compatibility
-        :param groups: Always ignored, exists for compatibility
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Dataframe with the data to split.
+        y : array-like | None, default=None
+            Ignored, present for compatibility.
+        groups : array-like | None, default=None
+            Ignored, present for compatibility.
+
+        Yields
+        -------
+        tuple[np.ndarray, np.ndarray]
+            Train and test indices of the same fold.
         """
 
         X_index_df = self._join_date_and_x(X)
@@ -110,8 +130,7 @@ class TimeGapSplit:
 
         if len(X) != len(X_index_df):
             raise AssertionError(
-                "X and X_index_df are not the same length, "
-                "there must be some index missing in 'self.date_serie'"
+                "X and X_index_df are not the same length, " "there must be some index missing in 'self.date_serie'"
             )
 
         date_min = X_index_df["__date__"].min()
@@ -119,20 +138,12 @@ class TimeGapSplit:
         date_length = X_index_df["__date__"].max() - X_index_df["__date__"].min()
 
         if (self.train_duration is None) and (self.n_splits is not None):
-            self.train_duration = date_length - (
-                self.gap_duration + self.valid_duration * self.n_splits
-            )
+            self.train_duration = date_length - (self.gap_duration + self.valid_duration * self.n_splits)
 
-        if (self.train_duration is not None) and (
-            self.train_duration <= self.gap_duration
-        ):
-            raise ValueError(
-                "gap_duration is longer than train_duration, it should be shorter."
-            )
+        if (self.train_duration is not None) and (self.train_duration <= self.gap_duration):
+            raise ValueError("gap_duration is longer than train_duration, it should be shorter.")
 
-        n_split_max = (
-            date_length - self.train_duration - self.gap_duration
-        ) / self.valid_duration
+        n_split_max = (date_length - self.train_duration - self.gap_duration) / self.valid_duration
         if self.n_splits:
             if n_split_max < self.n_splits:
                 raise ValueError(
@@ -152,27 +163,17 @@ class TimeGapSplit:
         else:
             time_shift = self.valid_duration
         while True:
-            if (
-                current_date + self.train_duration + time_shift + self.gap_duration
-                > date_max
-            ):
+            if current_date + self.train_duration + time_shift + self.gap_duration > date_max:
                 break
 
             X_train_df = X_index_df[
-                (X_index_df["__date__"] >= start_date)
-                & (X_index_df["__date__"] < current_date + self.train_duration)
+                (X_index_df["__date__"] >= start_date) & (X_index_df["__date__"] < current_date + self.train_duration)
             ]
             X_valid_df = X_index_df[
-                (
-                    X_index_df["__date__"]
-                    >= current_date + self.train_duration + self.gap_duration
-                )
+                (X_index_df["__date__"] >= current_date + self.train_duration + self.gap_duration)
                 & (
                     X_index_df["__date__"]
-                    < current_date
-                    + self.train_duration
-                    + self.valid_duration
-                    + self.gap_duration
+                    < current_date + self.train_duration + self.valid_duration + self.gap_duration
                 )
             ]
 
@@ -185,18 +186,36 @@ class TimeGapSplit:
             )
 
     def get_n_splits(self, X=None, y=None, groups=None):
-        """Gets the number of splits
+        """Get the number of splits
 
-        :return: amount of n_splits
-        :rtype: int
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Dataframe with the data to split.
+        y : array-like | None, default=None
+            Ignored, present for compatibility.
+        groups : array-like | None, default=None
+            Ignored, present for compatibility.
+
+        Returns
+        -------
+        int
+            Number of splits.
         """
         return sum(1 for x in self.split(X, y, groups))
 
     def summary(self, X):
-        """Describes all folds
+        """Describe all folds.
 
-        :param pandas.DataFrame X: Dataframe with the data to split
-        :returns: ``pd.DataFrame`` summary of all folds
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Dataframe with the data to split.
+
+        Returns
+        -------
+        pd.DataFrame
+            Summary of all folds.
         """
         summary = []
         X_index_df = self._join_date_and_x(X)
@@ -210,8 +229,7 @@ class TimeGapSplit:
                 {
                     "Start date": mindate,
                     "End date": maxdate,
-                    "Period": pd.to_datetime(maxdate, format="%Y%m%d")
-                    - pd.to_datetime(mindate, format="%Y%m%d"),
+                    "Period": pd.to_datetime(maxdate, format="%Y%m%d") - pd.to_datetime(mindate, format="%Y%m%d"),
                     "Unique days": len(dates.unique()),
                     "nbr samples": len(indices),
                 },
@@ -230,30 +248,37 @@ class TimeGapSplit:
 
 
 class KlusterFoldValidation:
-    """
-    KlusterFold cross validator
+    """KlusterFold cross validator. Create folds based on provided cluster method
 
-    - Create folds based on provided cluster method
-
-    :param cluster_method: Clustering method with fit_predict attribute
+    Parameters
+    ----------
+    cluster_method : Clusterer
+        Clustering method to use for the fold validation.
     """
 
     def __init__(self, cluster_method=None):
         if not isinstance(cluster_method, Clusterer):
-            raise ValueError(
-                "The KlusterFoldValidation only works on cluster methods with .fit_predict."
-            )
+            raise ValueError("The KlusterFoldValidation only works on cluster methods with .fit_predict.")
 
         self.cluster_method = cluster_method
         self.n_splits = None
 
     def split(self, X, y=None, groups=None):
-        """
-        Generator to iterate over the indices
+        """Generate indices to split data into training and test set.
 
-        :param X: Array to split on
-        :param y: Always ignored, exists for compatibility
-        :param groups: Always ignored, exists for compatibility
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Array to split on.
+        y : array-like of shape (n_samples,) | None, default=None
+            Ignored, present for compatibility.
+        groups : array-like of shape (n_samples,) | None, default=None
+            Ignored, present for compatibility.
+
+        Yields
+        -------
+        tuple[np.ndarray, np.ndarray]
+            Train and test indices of the same fold.
         """
 
         X = check_array(X)
@@ -265,9 +290,7 @@ class KlusterFoldValidation:
         self.n_splits = len(np.unique(clusters))
 
         if self.n_splits < 2:
-            raise ValueError(
-                f"Clustering method resulted in {self.n_splits} cluster, too few for fold validation"
-            )
+            raise ValueError(f"Clustering method resulted in {self.n_splits} cluster, too few for fold validation")
 
         for label in np.unique(clusters):
             yield (
@@ -276,10 +299,19 @@ class KlusterFoldValidation:
             )
 
     def _method_is_fitted(self, X):
+        """Check if the `cluster_method` is fitted
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Array to use if the method is fitted
+
+        Returns
+        -------
+        bool
+            True if fitted, else False
         """
-        :param X: Array to use if the method is fitted
-        :return: True if fitted, else False
-        """
+
         try:
             self.cluster_method.predict(X[0:1, :])
             return True
@@ -288,11 +320,10 @@ class KlusterFoldValidation:
 
 
 class GroupTimeSeriesSplit(_BaseKFold):
-    """
-    Sliding window time series split
+    """Sliding window time series split.
 
-    Create n_splits folds with an as equally possible size through a smart variant of a brute
-    force search. Groups parameter in .split() should be filled with the time groups (e.g. years)
+    Create `n_splits` folds with an as equally possible size through a smart variant of a brute force search.
+    Groups parameter in .split() method should be filled with the time groups (e.g. years)
 
     If n_splits is 3 ("*" = train, "x" = test)::
 
@@ -302,8 +333,10 @@ class GroupTimeSeriesSplit(_BaseKFold):
     | - - - - - - * * * x x |
     |-----------------------|
 
-    :param n_splits: the amount of train-test combinations.
-    :type n_splits: int
+    Parameters
+    ----------
+    n_splits : int
+        Amount of (train, test) splits to generate.
     """
 
     # table above inspired by sktime
@@ -326,50 +359,42 @@ class GroupTimeSeriesSplit(_BaseKFold):
         self.n_splits = n_splits
 
     def summary(self):
-        """
-        Generates a pd.DataFrame which displays the groups splits
-        and extra statistics about it.
-        Can only be run after having applied the .split() method to
-        the GroupTimeSeriesSplit instance.
+        """Describe all folds in a pd.DataFrame which displays the groups splits and extra statistics about it.
 
-        :return: a pd.DataFrame with info about where the splits were made
-        :rtype: pd.DataFrame
+        Can only be run after having applied the `.split()` method to the `GroupTimeSeriesSplit` instance.
+
+        Returns
+        -------
+        pd.DataFrame
+            Summary of all folds.
         """
         try:
             return (
                 self._grouped_df.sort_index()
                 .assign(group=lambda df: df["group"].astype(int))
-                .assign(
-                    obs_per_group=lambda df: df.groupby("group")[
-                        "observations"
-                    ].transform("sum")
-                )
+                .assign(obs_per_group=lambda df: df.groupby("group")["observations"].transform("sum"))
                 .assign(ideal_group_size=round(self._ideal_group_size))
-                .assign(
-                    diff_from_ideal_group_size=lambda df: df["obs_per_group"]
-                    - df["ideal_group_size"]
-                )
+                .assign(diff_from_ideal_group_size=lambda df: df["obs_per_group"] - df["ideal_group_size"])
             )
         except AttributeError:
-            raise AttributeError(
-                ".summary() only works after having ran" " .split(X, y, groups)."
-            )
+            raise AttributeError(".summary() only works after having ran" " .split(X, y, groups).")
 
     def split(self, X=None, y=None, groups=None):
-        """Returns the train-test splits of all the folds
+        """Generate the train-test splits of all the folds
 
-        :param X: array-like of shape (n_samples, n_features)
-            Training data, where `n_samples` is the number of samples
-            and `n_features` is the number of features, defaults to None
-        :type X: np.array, optional
-        :param y: array-like of shape (n_samples,)
-            The target variable for supervised learning problems, defaults to None
-        :type y: np.array, optional
-        :param groups: Group labels for the samples used while splitting the dataset
-            into train/test set, defaults to None
-        :type groups: np.array
-        :return: the indices of the train and test splits
-        :rtype: List[np.array]
+        Parameters:
+        -----------
+        X : array-like of shape (n_samples, n_features), default=None
+            Data to split.
+        y : array-like of shape (n_samples,), default=None
+            The target variable for supervised learning problems.
+        groups : array-like of shape (n_samples,), default=None
+            Group labels for the samples used while splitting the dataset into train/test set,
+
+        Returns
+        -------
+        List[np.ndarray]
+            List containing train-test split indices of each fold.
         """
         if groups is None:
             raise ValueError("Groups cannot be None")
@@ -377,34 +402,42 @@ class GroupTimeSeriesSplit(_BaseKFold):
         n_groups = np.unique(groups).shape[0]
         if self.n_splits >= n_groups:
             raise ValueError(
-                (
-                    "n_splits({0}) must be less than the amount"
-                    " of unique groups({1})."
-                ).format(self.n_splits, n_groups)
+                ("n_splits({0}) must be less than the amount" " of unique groups({1}).").format(self.n_splits, n_groups)
             )
         return list(self._iter_test_indices(X, y, groups))
 
     def get_n_splits(self, X=None, y=None, groups=None):
         """Get the amount of splits
 
-        :param X: Always ignored, exists for compatibality, defaults to None
-        :type X: Object, optional
-        :param y: Always ignored, exists for compatibality, defaults to None
-        :type y: Object, optional
-        :param groups: Always ignored, exists for compatibality, defaults to None
-        :type groups: Object, optional
-        :return: amount of n_splits
-        :rtype: int
+        Parameters:
+        -----------
+        X : array-like of shape (n_samples, n_features), default=None
+            Ignored, present for compatibility.
+        y : array-like of shape (n_samples,), default=None
+            Ignored, present for compatibility.
+        groups : array-like of shape (n_samples,), default=None
+            Ignored, present for compatibility.
+
+        Returns
+        -------
+        int
+            Amount of splits.
         """
         return self.n_splits
 
     def _check_for_long_estimated_runtime(self, groups):
-        """
-        Checks for combinations of n_splits and unique groups and raises UserWarning
-        if runtime is expected to take over one minute
+        """Check for combinations of n_splits and unique groups and raises `UserWarning` if runtime is expected to take
+        over one minute.
 
-        :param groups: array of the groups
-        :type groups: np.array
+        Parameters
+        -----------
+        groups : array-like of shape (n_samples,)
+            Groups to check for unique groups and n_splits.
+
+        Raises
+        ------
+        UserWarning
+            If runtime is expected to take over one minute.
         """
         unique_groups = len(set(groups))
         warning = (
@@ -431,16 +464,21 @@ class GroupTimeSeriesSplit(_BaseKFold):
             )
 
     def _iter_test_indices(self, X=None, y=None, groups=None):
-        """
-        Calculates the optimal division of groups into folds so that every fold is as
-        equally large as possible
+        """Calculate the optimal division of groups into folds so that every fold is as equally large as possible.
 
-        :param X: Always ignored, exists for compatibility.
-        :param y: Always ignored, exists for compatibility.
-        :param groups: array with groups
-        :type groups: np.array
+        Parameters:
+        -----------
+        X : array-like of shape (n_samples, n_features), default=None
+            Ignored, present for compatibility.
+        y : array-like of shape (n_samples,), default=None
+            Ignored, present for compatibility.
+        groups : array-like of shape (n_samples,), default=None
+            Array with groups.
 
-        :yields: two numpy arrays -> train indices and test indices of the same fold
+        Yields
+        ------
+        tuple[np.ndarray, np.ndarray]
+            Train and test indices of the same fold.
         """
         self._check_for_long_estimated_runtime(groups)
         (
@@ -453,17 +491,22 @@ class GroupTimeSeriesSplit(_BaseKFold):
             yield np.where(groups == i)[0], np.where(groups == i + 1)[0]
 
     def _calc_first_and_last_split_index(self, X=None, y=None, groups=None):
-        """
-        Calculates an approximate first and last split point to reduce the amount
-        of options during a brute force search.
+        """Calculate an approximate first and last split point to reduce the amount of options during a brute force
+        search.
 
-        :param X: Always ignored, exists for compatibility.
-        :param y: Always ignored, exists for compatibility.
-        :param groups: array with groups
-        :type groups: np.array
+        Parameters:
+        -----------
+        X : array-like of shape (n_samples, n_features), default=None
+            Ignored, present for compatibility.
+        y : array-like of shape (n_samples,), default=None
+            Ignored, present for compatibility.
+        groups : array-like of shape (n_samples,), default=None
+            Array with groups.
 
-        :return: approximate index of first and approx. index of last split
-        :rtype: tuple
+        Returns
+        -------
+        tuple[int, int]
+            Approximate first and last split indexes.
         """
 
         # get the counts (=amount of rows) for each group
@@ -478,9 +521,7 @@ class GroupTimeSeriesSplit(_BaseKFold):
         )
 
         # set the ideal group_size and reduce it to 90% to have some leverage
-        self._ideal_group_size = np.sum(self._grouped_df["observations"]) / (
-            self.n_splits + 1
-        )
+        self._ideal_group_size = np.sum(self._grouped_df["observations"]) / (self.n_splits + 1)
         init_ideal_group_size = self._ideal_group_size * 0.9
 
         # initialize the index of the first split, to reduce the amount of possible index split options
@@ -508,12 +549,13 @@ class GroupTimeSeriesSplit(_BaseKFold):
         return first_split_index, last_split_index
 
     def _get_split_indices(self):
-        """
-        Calculates for each possible splits the total absolute different of the groups
-        to the ideal group size and saves the split with the least absolute difference.
+        """Calculate for each possible splits the total absolute different of the groups to the ideal group size and
+        saves the split with the least absolute difference.
 
-        :return: indices of the best split points
-        :rtype: tuple
+        Returns
+        -------
+        int
+            Index of the best split point.
         """
         # set the index range to search possible splits for
         index_range = range(self._first_split_index, self._last_split_index)
@@ -535,23 +577,16 @@ class GroupTimeSeriesSplit(_BaseKFold):
         # create a new generator that starts from the beginning again
         splits_generator = combinations(index_range, self.n_splits)
 
-        # generate a list, with for every group the difference between them and the ideal group size
-        # e.g.
+        # generate a list, with for every group the difference between them and the ideal group size, e.g.
         # ideal_group_size = 100
         # group_sizes = [10,20,270]
         # diff_from_ideal_list = [-90, -80, 170]
-        diff_from_ideal_list = [
-            sum(observations[: first_splits[0]]) - self._ideal_group_size
-        ]
+        diff_from_ideal_list = [sum(observations[: first_splits[0]]) - self._ideal_group_size]
         for split in sliding_window(first_splits, window_size=2, step_size=1):
             try:
-                diff_from_ideal_list += [
-                    sum(observations[split[0] : split[1]]) - self._ideal_group_size
-                ]
+                diff_from_ideal_list += [sum(observations[split[0] : split[1]]) - self._ideal_group_size]
             except IndexError:
-                diff_from_ideal_list += [
-                    sum(observations[split[0] :]) - self._ideal_group_size
-                ]
+                diff_from_ideal_list += [sum(observations[split[0] :]) - self._ideal_group_size]
 
         # keep track of the minimum of the total difference from all groups to the ideal group size
         min_diff = sum([abs(diff) for diff in diff_from_ideal_list])
@@ -560,13 +595,10 @@ class GroupTimeSeriesSplit(_BaseKFold):
         # loop through all possible split points and check whether a new split
         # has a less total difference from all groups to the ideal group size
         for prev_splits, new_splits in zip(splits_generator, splits_generator_shifted):
-            diff_from_ideal_list = self._calc_new_diffs(
-                observations, diff_from_ideal_list, prev_splits, new_splits
-            )
+            diff_from_ideal_list = self._calc_new_diffs(observations, diff_from_ideal_list, prev_splits, new_splits)
             new_diff = sum([abs(diff) for diff in diff_from_ideal_list])
 
-            # if with the new split the difference is less than the current most optimal, save the
-            # new split
+            # if with the new split the difference is less than the current most optimal, save the new split
             if new_diff < min_diff:
                 min_diff = new_diff
                 best_splits = new_splits
@@ -574,29 +606,29 @@ class GroupTimeSeriesSplit(_BaseKFold):
 
     @staticmethod
     def _calc_new_diffs(values, diff_list, prev_splits, new_splits):
-        """Calculates the new group size differences compared to the optimal group size
+        """Calculate the new group size differences compared to the optimal group size.
 
-        :param values: list of values
-        :type values: list
-        :param diff_list: list of values with for each index split its difference
-            from the optimal group size
-        :type diff_list: list
-        :param prev_splits: the indices of the previous splits, excluding index 0 and the last index
-        :type prev_splits: tuple
-        :param new_splits: the indices of the new splits, excluding index 0 and the last index
-        :type new_splits: tuple
+        Parameters
+        ----------
+        values : list
+            List of values.
+        diff_list : list
+            List of values with for each index split its difference from the optimal group size.
+        prev_splits : tuple
+            Indices of the previous splits, excluding index 0 and the last index.
+        new_splits : tuple
+            Indices of the new splits, excluding index 0 and the last index.
 
-        :return: updated diff_list
-        :rtype: list
+        Returns
+        -------
+        list
+            List of values with for each index split its difference from the optimal group size.
         """
         # calculate which indices have changed, e.g.:
         # new_index = (1,2,5)
         # prev_index = (1,2,4)
         # index_diffs = (0,0,1)
-        index_diffs = [
-            new_index - prev_index
-            for prev_index, new_index in zip(prev_splits, new_splits)
-        ]
+        index_diffs = [new_index - prev_index for prev_index, new_index in zip(prev_splits, new_splits)]
         new_diff_list = diff_list.copy()
 
         # calculate the effects of the index change to the groups
@@ -621,15 +653,19 @@ class GroupTimeSeriesSplit(_BaseKFold):
         return new_diff_list
 
     def _regroup(self, groups):
-        """
-        Specifies in which group every observation belongs
+        """Specify in which group every observation belongs.
 
-        :param groups: original groups in array
-        :type: groups: np.array
+        Parameters
+        ----------
+        groups : array-like of shape (n_samples,)
+            Array with original groups.
 
-        :return: indices for the train and test splits of each fold
-        :rtype: np.array
+        Returns
+        -------
+        np.ndarray
+            Indices for the train and test splits of each fold
         """
+
         df = self._grouped_df.copy().reset_index()
         # set each unique group to the right group_id to group them into folds
         df.loc[: self._best_splits[0], "group"] = 0
@@ -645,9 +681,17 @@ class GroupTimeSeriesSplit(_BaseKFold):
         return np.vectorize(mapper.get)(groups)
 
     def _method_is_fitted(self, X):
-        """
-        :param X: Array to use if the method is fitted
-        :return: True if fitted, else False
+        """Check if the `cluster_method` is fitted
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Array to use if the method is fitted
+
+        Returns
+        -------
+        bool
+            True if fitted, else False
         """
         try:
             self.cluster_method.predict(X[0:1, :])

--- a/sklego/model_selection.py
+++ b/sklego/model_selection.py
@@ -19,25 +19,26 @@ class TimeGapSplit:
     This cross-validation object is a variation of TimeSeriesSplit with the following  differences:
 
     - The splits are made based on datetime duration, instead of number of rows.
-    - The user specifies the validation durations and either training_duration or n_splits.
-    - The user can specify a 'gap' duration that is added after the training split and before the validation split.
+    - The user specifies the `valid_duration` and either `train_duration` or `n_splits`.
+    - The user can specify a `gap_duration` that is added after the training split and before the validation split.
 
     The 3 duration parameters can be used to really replicate how the model is going to be used in production in batch
     learning.
 
-    Each validation fold doesn't overlap. The entire 'window' moves by 1 'valid_duration'
-    until there is not enough data.
+    Each validation fold doesn't overlap. The entire `window` moves by 1 `valid_duration` until there is not enough
+    data.
 
-    If this would lead to more splits then specified with 'n_splits', the 'window' moves by
-    the 'validation_duration' times the fraction of possible splits and requested splits:
+    If this would lead to more splits then specified with `n_splits`, the `window` moves by `valid_duration` times the
+    fraction of possible splits and requested splits:
 
-    - n_possible_splits = (total_length - train_duration-gap_duration) // valid_duration
-    - time_shift = valid_duration * n_possible_splits / n_slits
+    - `n_possible_splits = (total_length - train_duration-gap_duration) // valid_duration`
+    - `time_shift = valid_duration * n_possible_splits / n_slits`
+
     so the CV spans the whole dataset.
 
-    If 'train_duration' is not passed but 'n_splits' is, the training duration is increased to:
+    If `train_duration` is not passed but `n_splits` is, the training duration is increased to:
 
-        train_duration = total_length - (gap_duration + valid_duration * n_splits)
+    `train_duration = total_length - (gap_duration + valid_duration * n_splits)`
 
     such that the shifting the entire window by one validation duration spans the whole training set.
 
@@ -349,15 +350,15 @@ class GroupTimeSeriesSplit(_BaseKFold):
     """Sliding window time series split.
 
     Create `n_splits` folds with an as equally possible size through a smart variant of a brute force search.
-    Groups parameter in .split() method should be filled with the time groups (e.g. years)
+    Groups parameter in `.split()` method should be filled with the time groups (e.g. years)
 
-    If n_splits is 3 ("*" = train, "x" = test)::
+    If `n_splits` is 3 ("*" = train, "x" = test):
 
-    |-----------------------|
-    | * * * x x x - - - - - |
-    | - - - * * * x x x - - |
-    | - - - - - - * * * x x |
-    |-----------------------|
+    ```console
+    * * * x x x - - - - -
+    - - - * * * x x x - -
+    - - - - - - * * * x x
+    ```
 
     Parameters
     ----------
@@ -411,14 +412,14 @@ class GroupTimeSeriesSplit(_BaseKFold):
             )
         except AttributeError:
             raise AttributeError(
-                ".summary() only works after having ran" " .split(X, y, groups)."
+                ".summary() only works after having ran .split(X, y, groups)."
             )
 
     def split(self, X=None, y=None, groups=None):
         """Generate the train-test splits of all the folds
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         X : array-like of shape (n_samples, n_features), default=None
             Data to split.
         y : array-like of shape (n_samples,), default=None
@@ -447,8 +448,8 @@ class GroupTimeSeriesSplit(_BaseKFold):
     def get_n_splits(self, X=None, y=None, groups=None):
         """Get the amount of splits
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         X : array-like of shape (n_samples, n_features), default=None
             Ignored, present for compatibility.
         y : array-like of shape (n_samples,), default=None
@@ -468,7 +469,7 @@ class GroupTimeSeriesSplit(_BaseKFold):
         over one minute.
 
         Parameters
-        -----------
+        ----------
         groups : array-like of shape (n_samples,)
             Groups to check for unique groups and n_splits.
 
@@ -504,8 +505,8 @@ class GroupTimeSeriesSplit(_BaseKFold):
     def _iter_test_indices(self, X=None, y=None, groups=None):
         """Calculate the optimal division of groups into folds so that every fold is as equally large as possible.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         X : array-like of shape (n_samples, n_features), default=None
             Ignored, present for compatibility.
         y : array-like of shape (n_samples,), default=None
@@ -532,8 +533,8 @@ class GroupTimeSeriesSplit(_BaseKFold):
         """Calculate an approximate first and last split point to reduce the amount of options during a brute force
         search.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         X : array-like of shape (n_samples, n_features), default=None
             Ignored, present for compatibility.
         y : array-like of shape (n_samples,), default=None

--- a/sklego/naive_bayes.py
+++ b/sklego/naive_bayes.py
@@ -1,19 +1,28 @@
 import numpy as np
-
 from sklearn.base import BaseEstimator, ClassifierMixin
-from sklearn.mixture import GaussianMixture, BayesianGaussianMixture
+from sklearn.mixture import BayesianGaussianMixture, GaussianMixture
 from sklearn.utils import check_X_y
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import check_is_fitted, check_array, FLOAT_DTYPES
+from sklearn.utils.validation import FLOAT_DTYPES, check_array, check_is_fitted
 
 
 class GaussianMixtureNB(BaseEstimator, ClassifierMixin):
-    """
-    The GaussianMixtureNB trains a Naive Bayes Classifier that uses a mixture
-    of gaussians instead of merely training a single one.
+    """The `GaussianMixtureNB` estimator is a naive bayes classifier that uses a mixture of gaussians instead of
+    merely a single one. In particular it trains a `GaussianMixture` model for each class in the target and for each
+    feature in the data, on the subset of `X` where `y == class`.
 
-    You can pass any keyword parameter that scikit-learn's Gaussian Mixture
-    Model uses and it will be passed along.
+    You can pass any keyword parameter that scikit-learn's
+    [GaussianMixture](https://scikit-learn.org/stable/modules/generated/sklearn.mixture.GaussianMixture.html)
+    model uses and it will be passed along to each of the models.
+
+    Attributes
+    ----------
+    gmms_ : dict[int, List[GaussianMixture]]
+        A dictionary of Gaussian Mixture Models, one for each class.
+    classes_ : np.ndarray of shape (n_classes,)
+        The classes seen during `fit`.
+    num_fit_cols_ : int
+        The number of features seen during `fit`.
     """
 
     def __init__(
@@ -44,13 +53,21 @@ class GaussianMixtureNB(BaseEstimator, ClassifierMixin):
         self.random_state = random_state
         self.warm_start = warm_start
 
-    def fit(self, X: np.array, y: np.array) -> "GaussianMixtureNB":
-        """
-        Fit the model using X, y as training data.
+    def fit(self, X, y) -> "GaussianMixtureNB":
+        """Fit the `GaussianMixtureNB` estimator using `X` and `y` as training data by fitting a `GaussianMixture` model
+        for each class in the target and for each feature in the data, on the subset of `X` where `y == class`.
 
-        :param X: array-like, shape=(n_columns, n_samples, ) training data.
-        :param y: array-like, shape=(n_samples, ) training data.
-        :return: Returns an instance of self.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features )
+            The training data.
+        y : array-like of shape (n_samples,)
+            The target values.
+
+        Returns
+        -------
+        self : GaussianMixtureNB
+            The fitted estimator.
         """
         X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         if X.ndim == 1:
@@ -81,38 +98,69 @@ class GaussianMixtureNB(BaseEstimator, ClassifierMixin):
         return self
 
     def predict(self, X):
+        """Predict labels for `X` using fitted estimator and `predict_proba` method, by picking the class with the
+        highest probability.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples,)
+            The predicted data.
+        """
         check_is_fitted(self, ["gmms_", "classes_"])
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         return self.classes_[self.predict_proba(X).argmax(axis=1)]
 
-    def predict_proba(self, X: np.array):
+    def predict_proba(self, X: np.ndarray):
+        """Predict probabilities for `X` using fitted estimator by summing the probabilities of each gaussian for each
+        class.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples, n_classes)
+            The predicted probabilities.
+        """
         check_is_fitted(self, ["gmms_", "classes_"])
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         if self.num_fit_cols_ != X.shape[1]:
-            raise ValueError(
-                f"number of columns {X.shape[1]} does not match fit size {self.num_fit_cols_}"
-            )
+            raise ValueError(f"number of columns {X.shape[1]} does not match fit size {self.num_fit_cols_}")
         check_is_fitted(self, ["gmms_", "classes_"])
         probs = np.zeros((X.shape[0], len(self.classes_)))
         for k, v in self.gmms_.items():
             class_idx = int(np.argwhere(self.classes_ == k))
             probs[:, class_idx] = np.array(
-                [
-                    m.score_samples(np.expand_dims(X[:, idx], 1))
-                    for idx, m in enumerate(v)
-                ]
+                [m.score_samples(np.expand_dims(X[:, idx], 1)) for idx, m in enumerate(v)]
             ).sum(axis=0)
         likelihood = np.exp(probs)
         return likelihood / likelihood.sum(axis=1).reshape(-1, 1)
 
 
 class BayesianGaussianMixtureNB(BaseEstimator, ClassifierMixin):
-    """
-    The BayesianGaussianMixtureNB trains a Naive Bayes Classifier that uses a bayesian
-    mixture of gaussians instead of merely training a single one.
+    """The `BayesianGaussianMixtureNB` estimator is a naive bayes classifier that uses a bayesian mixture of gaussians
+    instead of merely a single one. In particular it trains a `BayesianGaussianMixture` model for each class in the
+    target and for each feature in the data, on the subset of `X` where `y == class`.
 
-    You can pass any keyword parameter that scikit-learn's Bayesian Gaussian Mixture
-    Model uses and it will be passed along.
+    You can pass any keyword parameter that scikit-learn's
+    [`BayesianGaussianMixture`](https://scikit-learn.org/stable/modules/generated/sklearn.mixture.BayesianGaussianMixture.html)
+    model uses and it will be passed along to each of the models.
+
+    Attributes
+    ----------
+    gmms_ : dict[int, List[BayesianGaussianMixture]]
+        A dictionary of Gaussian Mixture Models, one for each class.
+    classes_ : np.ndarray of shape (n_classes,)
+        The classes seen during `fit`.
+    num_fit_cols_ : int
+        The number of features seen during `fit`.
     """
 
     def __init__(
@@ -153,13 +201,22 @@ class BayesianGaussianMixtureNB(BaseEstimator, ClassifierMixin):
         self.verbose = verbose
         self.verbose_interval = verbose_interval
 
-    def fit(self, X: np.array, y: np.array) -> "BayesianGaussianMixtureNB":
-        """
-        Fit the model using X, y as training data.
+    def fit(self, X, y) -> "BayesianGaussianMixtureNB":
+        """Fit the `BayesianGaussianMixtureNB` estimator using `X` and `y` as training data by fitting a
+        `BayesianGaussianMixture` model for each class in the target and for each feature in the data, on the subset of
+        `X` where `y == class`.
 
-        :param X: array-like, shape=(n_columns, n_samples, ) training data.
-        :param y: array-like, shape=(n_samples, ) training data.
-        :return: Returns an instance of self.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features )
+            The training data.
+        y : array-like of shape (n_samples,)
+            The target values.
+
+        Returns
+        -------
+        self : BayesianGaussianMixtureNB
+            The fitted estimator.
         """
         X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         if X.ndim == 1:
@@ -195,26 +252,47 @@ class BayesianGaussianMixtureNB(BaseEstimator, ClassifierMixin):
         return self
 
     def predict(self, X):
+        """Predict labels for `X` using fitted estimator and `predict_proba` method, by picking the class with the
+        highest probability.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples,)
+            The predicted data.
+        """
         check_is_fitted(self, ["gmms_", "classes_", "num_fit_cols_"])
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         return self.classes_[self.predict_proba(X).argmax(axis=1)]
 
-    def predict_proba(self, X: np.array):
+    def predict_proba(self, X: np.ndarray):
+        """Predict probabilities for `X` using fitted estimator by summing the probabilities of each gaussian for each
+        class.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples, n_classes)
+            The predicted probabilities.
+        """
         check_is_fitted(self, ["gmms_", "classes_", "num_fit_cols_"])
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         if self.num_fit_cols_ != X.shape[1]:
-            raise ValueError(
-                f"number of columns {X.shape[1]} does not match fit size {self.num_fit_cols_}"
-            )
+            raise ValueError(f"number of columns {X.shape[1]} does not match fit size {self.num_fit_cols_}")
         check_is_fitted(self, ["gmms_", "classes_"])
         probs = np.zeros((X.shape[0], len(self.classes_)))
         for k, v in self.gmms_.items():
             class_idx = int(np.argwhere(self.classes_ == k))
             probs[:, class_idx] = np.array(
-                [
-                    m.score_samples(np.expand_dims(X[:, idx], 1))
-                    for idx, m in enumerate(v)
-                ]
+                [m.score_samples(np.expand_dims(X[:, idx], 1)) for idx, m in enumerate(v)]
             ).sum(axis=0)
         likelihood = np.exp(probs)
         return likelihood / likelihood.sum(axis=1).reshape(-1, 1)

--- a/sklego/neighbors.py
+++ b/sklego/neighbors.py
@@ -3,10 +3,27 @@ from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.neighbors import KernelDensity
 from sklearn.utils import check_X_y
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import check_is_fitted, check_array, FLOAT_DTYPES
+from sklearn.utils.validation import FLOAT_DTYPES, check_array, check_is_fitted
 
 
 class BayesianKernelDensityClassifier(BaseEstimator, ClassifierMixin):
+    """The `BayesianKernelDensityClassifier` estimator trains using Kernel Density estimations to generate the joint
+    distribution.
+
+    You can pass any keyword parameter that scikit-learn's
+    [KernelDensity](https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KernelDensity.html)
+    model uses and it will be passed along.
+
+    Attributes
+    ----------
+    classes_ : np.ndarray of shape (n_classes,)
+        The classes seen during `fit`.
+    models_ : dict[int, KernelDensity]
+        The models for each class seen during `fit`.
+    priors_logp_ : dict
+        The log priors for each class seen during `fit` (estimated as `np.log(len(x_subset) / len(X))`)
+    """
+
     def __init__(
         self,
         bandwidth=0.2,
@@ -19,11 +36,6 @@ class BayesianKernelDensityClassifier(BaseEstimator, ClassifierMixin):
         leaf_size=40,
         metric_params=None,
     ):
-        """
-        Bayesian Classifier that uses Kernel Density Estimations to generate the joint distribution
-
-        All parameters of the model are an exact copy of the parameters in scikit-learn.
-        """
         self.bandwidth = bandwidth
         self.kernel = kernel
         self.algorithm = algorithm
@@ -35,12 +47,20 @@ class BayesianKernelDensityClassifier(BaseEstimator, ClassifierMixin):
         self.metric_params = metric_params
 
     def fit(self, X: np.ndarray, y: np.ndarray):
-        """
-        Fit the model using X, y as training data.
+        """Fit the `BayesianKernelDensityClassifier` estimator using `X` and `y` as training data by fitting a
+        `KernelDensity` model for each class on the subset of X where y == class.
 
-        :param X: array-like, shape=(n_features, n_samples)
-        :param y: array-like, shape=(n_samples)
-        :return: Returns an instance of self
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The training data.
+        y : array-like of shape (n_samples,)
+            The target values.
+
+        Returns
+        -------
+        self : BayesianKernelDensityClassifier
+            The fitted estimator.
         """
         X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
 
@@ -68,29 +88,26 @@ class BayesianKernelDensityClassifier(BaseEstimator, ClassifierMixin):
         return self
 
     def predict_proba(self, X):
-        """
-        Probability estimates.
+        """Predict probabilities for `X` using fitted estimator and the joint distribution.
 
         The returned estimates for all classes are in the same order found in the `.classes_` attribute.
 
-        :param X: array-like of shape (n_samples, n_features)
-        :return: array-like of shape (n_samples, n_classes)
-            Returns the probability of the sample for each class in the model,
-            where classes are ordered as they are in self.classes_.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples, n_classes)
+            The predicted probabilities for each class, ordered as in `self.classes_`.
         """
         check_is_fitted(self)
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
 
-        log_prior = np.array(
-            [self.priors_logp_[target_label] for target_label in self.classes_]
-        )
+        log_prior = np.array([self.priors_logp_[target_label] for target_label in self.classes_])
 
-        log_likelihood = np.array(
-            [
-                self.models_[target_label].score_samples(X)
-                for target_label in self.classes_
-            ]
-        ).T
+        log_likelihood = np.array([self.models_[target_label].score_samples(X) for target_label in self.classes_]).T
 
         log_likelihood_and_prior = np.exp(log_likelihood + log_prior)
         evidence = log_likelihood_and_prior.sum(axis=1, keepdims=True)
@@ -98,11 +115,18 @@ class BayesianKernelDensityClassifier(BaseEstimator, ClassifierMixin):
         return posterior
 
     def predict(self, X):
-        """
-        Predict class labels for samples in X.
+        """Predict labels for `X` using fitted estimator and `predict_proba()` method, by taking the class with the
+        highest probability.
 
-        :param X: array_like, shape (n_samples, n_features)
-        :return: array, shape (n_samples)
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to predict.
+
+        Returns
+        -------
+        array-like of shape (n_samples,)
+            The predicted data.
         """
         check_is_fitted(self)
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)

--- a/sklego/notinstalled.py
+++ b/sklego/notinstalled.py
@@ -2,18 +2,24 @@ KNOWN_PACKAGES = {"cvxpy": {"version": ">=1.0.24", "extra_name": "cvxpy"}}
 
 
 class NotInstalledPackage:
-    """
-    Class to gracefully catch ImportErrors for modules and packages that are not installed
+    """Class to gracefully catch `ImportError`s for modules and packages that are not installed.
 
-    :param package_name (str): Name of the package you want to load
-    :param version (str, Optional): Version of the package
+    Parameters
+    ----------
+    package_name : str
+        Name of the package you want to load
+    version : str | None, default=None
+        Version of the package
 
-    Usage:
-        >>> try:
-        ...     import thispackagedoesnotexist as package
-        >>> except ImportError:
-        ...     from sklego.notinstalled import NotInstalledPackage
-        ...     package = NotInstalledPackage("thispackagedoesnotexist")
+    Examples
+    --------
+    ```py
+    try:
+        import thispackagedoesnotexist as package
+    except ImportError:
+        from sklego.notinstalled import NotInstalledPackage
+        package = NotInstalledPackage("thispackagedoesnotexist")
+    ```
     """
 
     def __init__(self, package_name: str, version: str = None):
@@ -35,7 +41,4 @@ class NotInstalledPackage:
         )
 
     def __getattr__(self, name):
-        raise ImportError(
-            f"The package {self.package_name}{self.version} is not installed. "
-            + self.pip_message
-        )
+        raise ImportError(f"The package {self.package_name}{self.version} is not installed. " + self.pip_message)

--- a/sklego/pandas_utils.py
+++ b/sklego/pandas_utils.py
@@ -10,10 +10,8 @@ from sklego.common import as_list
 
 
 def _get_shape_delta(old_shape, new_shape):
-    diffs = [
-        ("+" if new > old else "") + str(new - old)
-        for new, old in zip(new_shape, old_shape)
-    ]
+    """Returns a string with the difference in shape between old and new."""
+    diffs = [("+" if new > old else "") + str(new - old) for new, old in zip(new_shape, old_shape)]
 
     return f"delta=({', '.join(diffs)})"
 
@@ -30,29 +28,45 @@ def log_step(
     display_args=True,
     log_error=True,
 ):
-    """
-    Decorates a function that transforms a pandas dataframe to add automated logging statements
+    """Decorates a function that transforms a pandas dataframe to add automated logging statements.
 
-    :param func: callable, function to log, defaults to None
-    :param time_taken: bool, log the time it took to run a function, defaults to True
-    :param shape: bool, log the shape of the output result, defaults to True
-    :param shape_delta: bool, log the difference in shape of input and output, defaults to False
-    :param names: bool, log the names of the columns of the result, defaults to False
-    :param dtypes: bool, log the dtypes of the results, defaults to False
-    :param print_fn: callable, print function (e.g. print or logger.info), defaults to print
-    :param print_args: bool, whether or not to print the arguments given to the function.
-    :param log_error: bool, whether to add the Exception message to the log if the function fails, defaults to True.
-    :returns: the result of the function
+    Parameters
+    ----------
+    func : Callable | None, default=None
+        The function to decorate with logs. If None, returns a partial function with the given arguments.
+    time_taken : bool, default=True
+        Whether or not to log the time it took to run a function.
+    shape : bool, default=True
+        Whether or not to log the shape of the output result.
+    shape_delta : bool, default=False
+        Whether or not to log the difference in shape of input and output.
+    names : bool, default=False
+        Whether or not to log the names of the columns of the result.
+    dtypes : bool, default=False
+        Whether or not to log the dtypes of the result.
+    print_fn : Callable, default=print
+        Print function to use (e.g. `print` or `logger.info`)
+    display_args : bool, default=True
+        Whether or not to display the arguments given to the function.
+    log_error : bool, default=True
+        Whether or not to add the Exception message to the log if the function fails.
 
-    :Example:
-    >>> @log_step
-    ... def remove_outliers(df, min_obs=5):
-    ...     pass
+    Returns
+    -------
+    Callable
+        The decorated function.
 
-    >>> @log_step(print_fn=logging.info, shape_delta=True)
-    ... def remove_outliers(df, min_obs=5):
-    ...     pass
+    Examples
+    --------
+    ```py
+    @log_step
+    def remove_outliers(df, min_obs=5):
+        pass
 
+    @log_step(print_fn=logging.info, shape_delta=True)
+    def remove_outliers(df, min_obs=5):
+        pass
+    ```
     """
 
     if func is None:
@@ -98,9 +112,7 @@ def log_step(
 
             if display_args:
                 func_args = inspect.signature(func).bind(*args, **kwargs).arguments
-                func_args_str = "".join(
-                    ", {} = {!r}".format(*item) for item in list(func_args.items())[1:]
-                )
+                func_args_str = "".join(", {} = {!r}".format(*item) for item in list(func_args.items())[1:])
                 print_fn(
                     f"[{func.__name__}(df{func_args_str})] " + combined,
                 )
@@ -117,20 +129,29 @@ def log_step_extra(
     print_fn=print,
     **log_func_kwargs,
 ):
-    """
-    Decorates a function that transforms a pandas dataframe to add automated logging statements
+    """Decorates a function that transforms a pandas dataframe to add automated logging statements.
 
-    :param *log_functions: callable(s), functions that take the output of the decorated function and turn it into a log.
-                                        Note that the output of each log_function is casted to string using `str()`
-    :param print_fn: callable, print function (e.g. print or logger.info), defaults to print
-    :param **log_func_kwargs: keyword arguments to be passed to log_functions
-    :returns: the result of the function
+    Parameters
+    ----------
+    *log_functions : List[Callable]
+        Functions that take the output of the decorated function and turn it into a log.
+        Note that the output of each log_function is casted to string using `str()`.
+    print_fn: Callable, default=print
+        Print function (e.g. `print` or `logger.info`).
+    **log_func_kwargs: dict
+        Keyword arguments to be passed to `log_functions`
 
-    :Example:
-    >>> @log_step_extra(lambda d: d["some_column"].value_counts())
-    ... def remove_outliers(df, min_obs=5):
-    ...     pass
+    Returns:
+    Callable
+        The decorated function.
 
+    Examples
+    --------
+    ```py
+    @log_step_extra(lambda d: d["some_column"].value_counts())
+    def remove_outliers(df, min_obs=5):
+        pass
+    ```
     """
     if not log_functions:
         raise ValueError("Supply at least one log_function for log_step_extra")
@@ -141,14 +162,10 @@ def log_step_extra(
             result = func(*args, **kwargs)
 
             func_args = inspect.signature(func).bind(*args, **kwargs).arguments
-            func_args_str = "".join(
-                ", {} = {!r}".format(*item) for item in list(func_args.items())[1:]
-            )
+            func_args_str = "".join(", {} = {!r}".format(*item) for item in list(func_args.items())[1:])
 
             try:
-                extra_logs = " ".join(
-                    [str(log_f(result, **log_func_kwargs)) for log_f in log_functions]
-                )
+                extra_logs = " ".join([str(log_f(result, **log_func_kwargs)) for log_f in log_functions])
             except TypeError:
                 raise ValueError(
                     f"All log functions should be callable, got {[type(log_f) for log_f in log_functions]}"
@@ -166,44 +183,65 @@ def log_step_extra(
 
 
 def add_lags(X, cols, lags, drop_na=True):
-    """
-    Appends lag column(s).
+    """Appends lag column(s).
 
-    :param X: array-like, shape=(n_columns, n_samples,) training data.
-    :param cols: column name(s) or index (indices).
-    :param lags: the amount of lag for each col.
-    :param drop_na: remove rows that contain NA values.
-    :returns: ``pd.DataFrame | np.ndarray`` with only the selected cols.
+    Parameters
+    ----------
+    X : array-like
+        Data to be lagged.
+    cols : str | int | List[str] | List[int]
+        Column name(s) or index (indices).
+    lags : int | List[int]
+        The amount of lag for each col.
+    drop_na : bool, default=True
+        Whether or not to remove rows that contain NA values.
 
-    :Example:
+    Returns
+    -------
+    pd.DataFrame | np.ndarray
+        With only the selected cols.
 
-    >>> import pandas as pd
-    >>> df = pd.DataFrame([[1, 2, 3],
-    ...                    [4, 5, 6],
-    ...                    [7, 8, 9]],
-    ...                    columns=['a', 'b', 'c'],
-    ...                    index=[1, 2, 3])
+    Raises
+    ------
+    ValueError
+        If the input is not a `pd.DataFrame` or `np.ndarray`.
 
-    >>> add_lags(df, 'a', [1]) # doctest: +NORMALIZE_WHITESPACE
-       a  b  c  a1
+    Examples
+    --------
+    ```py
+    import pandas as pd
+    df = pd.DataFrame([[1, 2, 3],
+                       [4, 5, 6],
+                       [7, 8, 9]],
+            columns=["a", "b", "c"],
+            index=[1, 2, 3]
+    )
+
+    add_lags(df, "a", [1]) # doctest: +NORMALIZE_WHITESPACE
+    '''
+        a  b  c  a1
     1  1  2  3  4.0
     2  4  5  6  7.0
+    '''
 
-    >>> add_lags(df, ['a', 'b'], 2) # doctest: +NORMALIZE_WHITESPACE
-       a  b  c  a2   b2
+    add_lags(df, ["a", "b"], 2) # doctest: +NORMALIZE_WHITESPACE
+    '''
+        a  b  c  a2   b2
     1  1  2  3  7.0  8.0
+    '''
 
-    >>> import numpy as np
-    >>> X = np.array([[1, 2, 3],
-    ...               [4, 5, 6],
-    ...               [7, 8, 9]])
+    import numpy as np
+    X = np.array([[1, 2, 3],
+                  [4, 5, 6],
+                  [7, 8, 9]])
 
-    >>> add_lags(X, 0, [1])
-    array([[1, 2, 3, 4],
-           [4, 5, 6, 7]])
+    add_lags(X, 0, [1])
+    # array([[1, 2, 3, 4],
+    #        [4, 5, 6, 7]])
 
-    >>> add_lags(X, 1, [-1, 1])
-    array([[4, 5, 6, 2, 8]])
+    add_lags(X, 1, [-1, 1])
+    # array([[4, 5, 6, 2, 8]])
+    ```
     """
 
     # A single lag will be put in a list
@@ -232,13 +270,23 @@ def add_lags(X, cols, lags, drop_na=True):
 
 
 def _add_lagged_numpy_columns(X, cols, lags, drop_na):
-    """
-    Append a lag columns.
+    """Append a lag columns.
 
-    :param df: the input ``np.ndarray``.
-    :param cols: column index / indices.
-    :param drop_na: remove rows that contain NA values.
-    :returns: ``np.ndarray`` with the concatenated lagged cols.
+    Parameters
+    ----------
+    X : np.ndarray
+        Data to be lagged.
+    cols : int | List[int]
+        Column index / indices.
+    lags : int | List[int]
+        The amount of lag for each col.
+    drop_na : bool
+        Whether or not to remove rows that contain NA values.
+
+    Returns
+    -------
+    np.ndarray
+        Array with concatenated lagged cols.
     """
 
     cols = as_list(cols)
@@ -268,13 +316,23 @@ def _add_lagged_numpy_columns(X, cols, lags, drop_na):
 
 
 def _add_lagged_pandas_columns(df, cols, lags, drop_na):
-    """
-    Append a lag columns.
+    """Append a lag columns.
 
-    :param df: the input ``pd.DataFrame``.
-    :param cols: column name(s).
-    :param drop_na: remove rows that contain NA values.
-    :returns: ``pd.DataFrame`` with the concatenated lagged cols.
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Data to be lagged.
+    cols : str | List[str]
+        Column name / names.
+    lags : int | List[int]
+        The amount of lag for each col.
+    drop_na : bool
+        Whether or not to remove rows that contain NA values.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with concatenated lagged cols.
     """
 
     cols = as_list(cols)
@@ -284,9 +342,7 @@ def _add_lagged_pandas_columns(df, cols, lags, drop_na):
     if not all([col in df.columns.values for col in cols]):
         raise KeyError("The column does not exist")
 
-    combos = (
-        df[col].shift(-lag).rename(col + str(lag)) for col in cols for lag in lags
-    )
+    combos = (df[col].shift(-lag).rename(col + str(lag)) for col in cols for lag in lags)
 
     answer = pd.concat([df, *combos], axis=1)
 

--- a/sklego/preprocessing/__init__.py
+++ b/sklego/preprocessing/__init__.py
@@ -14,13 +14,13 @@ __all__ = [
     "DictMapper",
 ]
 
-from .intervalencoder import IntervalEncoder
-from .randomadder import RandomAdder
-from .patsytransformer import PatsyTransformer
-from .pandastransformers import ColumnSelector, PandasTypeSelector, ColumnDropper
-from .projections import InformationFilter, OrthogonalTransformer
-from .repeatingbasis import RepeatingBasisFunction
 from .columncapper import ColumnCapper
-from .identitytransformer import IdentityTransformer
-from .outlier_remover import OutlierRemover
 from .dictmapper import DictMapper
+from .identitytransformer import IdentityTransformer
+from .intervalencoder import IntervalEncoder
+from .outlier_remover import OutlierRemover
+from .pandastransformers import ColumnDropper, ColumnSelector, PandasTypeSelector
+from .patsytransformer import PatsyTransformer
+from .projections import InformationFilter, OrthogonalTransformer
+from .randomadder import RandomAdder
+from .repeatingbasis import RepeatingBasisFunction

--- a/sklego/preprocessing/columncapper.py
+++ b/sklego/preprocessing/columncapper.py
@@ -5,69 +5,84 @@ from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
 
 
 class ColumnCapper(TransformerMixin, BaseEstimator):
-    """
-    Caps the values of columns according to the given quantile thresholds.
+    """The `ColumnCapper` transformer caps the values of columns according to the given quantile thresholds.
 
-    :type quantile_range: tuple or list, optional, default=(5.0, 95.0)
-    :param quantile_range: The quantile ranges to perform the capping. Their valus must
-        be in the interval [0; 100].
+    The capping is performed independently for each column of the input data. The quantile thresholds are computed
+    during the fitting phase. The capping is performed during the transformation phase.
 
-    :type interpolation: str, optional, default='linear'
-    :param interpolation: The interpolation method to compute the quantiles when the
-        desired quantile lies between two data points `i` and `j`. The Available values
-        are:
+    Parameters
+    ----------
+    quantile_range : Tuple[float, float] | List[float], default=(5.0, 95.0)
+        The quantile ranges to perform the capping. Their values must be in the interval [0; 100].
+    interpolation : Literal["linear", "lower", "higher", "midpoint", "nearest"], default="linear"
+        The interpolation method to compute the quantiles when the desired quantile lies between two data points `i`
+        and `j`. This value is passed to
+        [`numpy.nanquantile`](https://numpy.org/doc/stable/reference/generated/numpy.nanquantile.html) function.
 
-        * ``'linear'``: `i + (j - i) * fraction`, where `fraction` is the fractional part of\
-            the index surrounded by `i` and `j`.
-        * ``'lower'``: `i`.
-        * ``'higher'``: `j`.
-        * ``'nearest'``: `i` or `j` whichever is nearest.
-        * ``'midpoint'``: (`i` + `j`) / 2.
+        The Available values are:
 
-    :type discard_infs: bool, optional, default=False
-    :param discard_infs: Whether to discard ``-np.inf`` and ``np.inf`` values or not. If
-        ``False``, such values will be capped. If ``True``, they will be replaced by
-        ``np.nan``.
+        - `"linear"`: `i + (j - i) * fraction`, where `fraction` is the fractional part of the index surrounded by `i`
+            and `j`.
+        * `"lower"`: `i`.
+        * `"higher"`: `j`.
+        * `"nearest"`: `i` or `j` whichever is nearest.
+        * `"midpoint"`: (`i` + `j`) / 2.
+    discard_infs : bool, default=False
+        Whether to discard `-np.inf` and `np.inf` values or not. If False, such values will be capped. If True,
+        they will be replaced by `np.nan`.
 
-        .. note::
-            Setting ``discard_infs=True`` is important if the `inf` values are results
-            of divisions by 0, which are interpreted by ``pandas`` as ``-np.inf`` or
-            ``np.inf`` depending on the signal of the numerator.
+        !!! info
+            Setting `discard_infs=True` is important if the `inf` values are results of divisions by 0, which are
+            interpreted by `pandas` as `-np.inf` or `np.inf` depending on the sign of the numerator.
+    copy : bool, default=True
+        If False, try to avoid a copy and do inplace capping instead. This is not guaranteed to always work inplace;
+        e.g. if the data is not a NumPy array or scipy.sparse CSR matrix, a copy may still be returned.
 
-    :type copy: bool, optional, default=True
-    :param copy: If False, try to avoid a copy and do inplace capping instead. This is not
-        guaranteed to always work inplace; e.g. if the data is not a NumPy array or scipy.sparse
-        CSR matrix, a copy may still be returned.
+    Attributes
+    ----------
+    quantiles_ : np.ndarray of shape (2, n_features)
+        The computed quantiles for each column of the input data. The first row contains the lower quantile, the second
+        row contains the upper quantile.
+    n_columns_ : int
+        Number of features seen during `fit`.
 
-    :raises:
-        ``TypeError``, ``ValueError``
+    Examples
+    --------
+    ```py
+    import pandas as pd
+    import numpy as np
+    from sklego.preprocessing import ColumnCapper
 
-    :Example:
-
-    >>> import pandas as pd
-    >>> import numpy as np
-    >>> from sklego.preprocessing import ColumnCapper
-    >>> df = pd.DataFrame({'a':[2, 4.5, 7, 9], 'b':[11, 12, np.inf, 14]})
-    >>> df
+    df = pd.DataFrame({'a':[2, 4.5, 7, 9], 'b':[11, 12, np.inf, 14]})
+    df
+    '''
          a     b
     0  2.0  11.0
     1  4.5  12.0
     2  7.0   inf
     3  9.0  14.0
-    >>> capper = ColumnCapper()
-    >>> capper.fit_transform(df)
+    '''
+
+    capper = ColumnCapper()
+    capper.fit_transform(df)
+    '''
     array([[ 2.375, 11.1  ],
            [ 4.5  , 12.   ],
            [ 7.   , 13.8  ],
            [ 8.7  , 13.8  ]])
-    >>> capper = ColumnCapper(discard_infs=True) # Discarding infs
-    >>> df[['a', 'b']] = capper.fit_transform(df)
-    >>> df
+    '''
+
+    capper = ColumnCapper(discard_infs=True) # Discarding infs
+    df[['a', 'b']] = capper.fit_transform(df)
+    df
+    '''
            a     b
     0  2.375  11.1
     1  4.500  12.0
     2  7.000   NaN
     3  8.700  13.8
+    '''
+    ```
     """
 
     def __init__(
@@ -86,23 +101,26 @@ class ColumnCapper(TransformerMixin, BaseEstimator):
         self.copy = copy
 
     def fit(self, X, y=None):
+        """Fit the `ColumnCapper` transformer by computing quantiles for each column of `X`.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data used to compute the quantiles for capping.
+        y : array-like of shape (n_samples,), default=None
+            Ignored, present for compatibility.
+
+        Returns
+        -------
+        self : ColumnCapper
+            The fitted transformer.
+
+        Raises
+        ------
+        ValueError
+            If `X` contains non-numeric columns.
         """
-        Computes the quantiles for each column of ``X``.
-
-        :type X: pandas.DataFrame or numpy.ndarray
-        :param X: The column(s) from which the capping limit(s) will be computed.
-
-        :param y: Ignored.
-
-        :rtype: sklego.preprocessing.ColumnCapper
-        :returns: The fitted object.
-
-        :raises:
-            ``ValueError`` if ``X`` contains non-numeric columns
-        """
-        X = check_array(
-            X, copy=True, force_all_finite=False, dtype=FLOAT_DTYPES, estimator=self
-        )
+        X = check_array(X, copy=True, force_all_finite=False, dtype=FLOAT_DTYPES, estimator=self)
 
         # If X contains infs, we need to replace them by nans before computing quantiles
         np.putmask(X, (X == np.inf) | (X == -np.inf), np.nan)
@@ -110,18 +128,12 @@ class ColumnCapper(TransformerMixin, BaseEstimator):
         # There should be no column containing only nan cells at this point. If that's not the case,
         # it means that the user asked ColumnCapper to fit some column containing only nan or inf cells.
         nans_mask = np.isnan(X)
-        invalid_columns_mask = (
-            nans_mask.sum(axis=0) == X.shape[0]
-        )  # Contains as many nans as rows
+        invalid_columns_mask = nans_mask.sum(axis=0) == X.shape[0]  # Contains as many nans as rows
         if invalid_columns_mask.any():
-            raise ValueError(
-                "ColumnCapper cannot fit columns containing only inf/nan values"
-            )
+            raise ValueError("ColumnCapper cannot fit columns containing only inf/nan values")
 
         q = [quantile_limit / 100 for quantile_limit in self.quantile_range]
-        self.quantiles_ = np.nanquantile(
-            a=X, q=q, axis=0, overwrite_input=True, method=self.interpolation
-        )
+        self.quantiles_ = np.nanquantile(a=X, q=q, axis=0, overwrite_input=True, method=self.interpolation)
 
         # Saving the number of columns to ensure coherence between fit and transform inputs
         self.n_columns_ = X.shape[1]
@@ -129,18 +141,22 @@ class ColumnCapper(TransformerMixin, BaseEstimator):
         return self
 
     def transform(self, X):
-        """
-        Performs the capping on the column(s) of ``X``.
+        """Performs the capping on the column(s) of `X` according to the quantile thresholds computed during fitting.
 
-        :type X: pandas.DataFrame or numpy.ndarray
-        :param X: The column(s) for which the capping limit(s) will be applied.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data for which the capping limit(s) will be applied.
 
-        :rtype: numpy.ndarray
-        :returns: ``X`` values with capped limits.
+        Returns
+        -------
+        X : np.ndarray of shape (n_samples, n_features)
+            `X` values with capped limits.
 
-        :raises:
-            ``ValueError`` if the number of columns from ``X`` differs from the
-            number of columns when fitting
+        Raises
+        ------
+        ValueError
+            If the number of columns from `X` differs from the number of columns when fitting.
         """
         check_is_fitted(self, "quantiles_")
         X = check_array(
@@ -152,9 +168,7 @@ class ColumnCapper(TransformerMixin, BaseEstimator):
         )
 
         if X.shape[1] != self.n_columns_:
-            raise ValueError(
-                "X must have the same number of columns in fit and transform"
-            )
+            raise ValueError("X must have the same number of columns in fit and transform")
 
         if self.discard_infs:
             np.putmask(X, (X == np.inf) | (X == -np.inf), np.nan)
@@ -167,17 +181,26 @@ class ColumnCapper(TransformerMixin, BaseEstimator):
 
     @staticmethod
     def _check_quantile_range(quantile_range):
+        """Checks for the validity of quantile_range.
+
+        Parameters
+        ----------
+        quantile_range : Tuple[float, float] | List[float]
+            The quantile ranges to perform the capping. Their values must be in the interval [0; 100].
+
+        Raises
+        ------
+        TypeError
+            If `quantile_range` is not a tuple or a list.
+        ValueError
+            - If `quantile_range` does not contain exactly 2 elements.
+            - If `quantile_range` contains values outside of [0; 100].
+            - If `quantile_range` contains values in the wrong order.
         """
-        Checks for the validity of quantile_range.
-        """
-        if not isinstance(quantile_range, tuple) and not isinstance(
-            quantile_range, list
-        ):
+        if not isinstance(quantile_range, tuple) and not isinstance(quantile_range, list):
             raise TypeError("quantile_range must be a tuple or a list")
         if len(quantile_range) != 2:
-            raise ValueError(
-                "quantile_range must contain 2 elements: min_quantile and max_quantile"
-            )
+            raise ValueError("quantile_range must contain 2 elements: min_quantile and max_quantile")
 
         min_quantile, max_quantile = quantile_range
 
@@ -192,13 +215,18 @@ class ColumnCapper(TransformerMixin, BaseEstimator):
 
     @staticmethod
     def _check_interpolation(interpolation):
-        """
-        Checks for the validity of interpolation
+        """Checks for the validity of interpolation.
+
+        Parameters
+        ----------
+        interpolation : Literal["linear", "lower", "higher", "midpoint", "nearest"]
+            Interpolation method to compute the quantiles
+
+        Raises
+        ------
+        ValueError
+            If `interpolation` is not one of the allowed values.
         """
         allowed_interpolations = ("linear", "lower", "higher", "midpoint", "nearest")
         if interpolation not in allowed_interpolations:
-            raise ValueError(
-                "Available interpolation methods: {}".format(
-                    ", ".join(allowed_interpolations)
-                )
-            )
+            raise ValueError("Available interpolation methods: {}".format(", ".join(allowed_interpolations)))

--- a/sklego/preprocessing/dictmapper.py
+++ b/sklego/preprocessing/dictmapper.py
@@ -5,12 +5,20 @@ from sklearn.utils.validation import check_is_fitted
 
 
 class DictMapper(TransformerMixin, BaseEstimator):
-    """
-    Map the values of values of columns according to the input dictionary,
-    fall back to the default if the key is not present in the dictionary.
+    """The `DictMapper` transformer maps the values of columns according to the input `mapper` dictionary, fall back to
+    the `default` value if the key is not present in the dictionary.
 
-    :param mapper: The dictionary containing the mapping of the values
-    :param default: The value to fall back to if the value is not in the mapper
+    Parameters
+    ----------
+    mapper : dict[..., int]
+        The dictionary containing the mapping of the values.
+    default : int
+        The value to fall back to if the value is not in the mapper.
+
+    Attributes
+    ----------
+    dim_ : int
+        Number of features seen during `fit`.
     """
 
     def __init__(self, mapper, default):
@@ -18,16 +26,19 @@ class DictMapper(TransformerMixin, BaseEstimator):
         self.default = default
 
     def fit(self, X, y=None):
-        """
-        Checks the input dataframe and records the shape of it
+        """Checks the input data and records the number of features.
 
-        :type X: pandas.DataFrame or numpy.ndarray
-        :param X: The column(s) from which the mapping will be applied
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to fit.
+        y : array-like of shape (n_samples,), default=None
+            Ignored, present for compatibility.
 
-        :param y: Ignored.
-
-        :rtype: sklego.preprocessing.DictMapper
-        :returns: The fitted object.
+        Returns
+        -------
+        self : DictMapper
+            The fitted transformer.
         """
         X = check_array(
             X,
@@ -41,18 +52,22 @@ class DictMapper(TransformerMixin, BaseEstimator):
         return self
 
     def transform(self, X):
-        """
-        Performs the mapping on the column(s) of ``X``.
+        """Performs the mapping on the column(s) of `X`.
 
-        :type X: pandas.DataFrame or numpy.ndarray
-        :param X: The column(s) for which the mapping will be applied.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data for which the mapping will be applied.
 
-        :rtype: numpy.ndarray
-        :returns: ``X`` values with the mapping applied
+        Returns
+        -------
+        np.ndarray of shape (n_samples, n_features)
+            The data with the mapping applied.
 
-        :raises:
-            ``ValueError`` if the number of columns from ``X`` differs from the
-            number of columns when fitting
+        Raises
+        ------
+        ValueError
+            If the number of columns from `X` differs from the number of columns when fitting.
         """
         check_is_fitted(self, ["dim_"])
         X = check_array(
@@ -65,7 +80,5 @@ class DictMapper(TransformerMixin, BaseEstimator):
         )
 
         if X.shape[1] != self.dim_:
-            raise ValueError(
-                f"number of columns {X.shape[1]} does not match fit size {self.dim_}"
-            )
+            raise ValueError(f"number of columns {X.shape[1]} does not match fit size {self.dim_}")
         return np.vectorize(self.mapper.get, otypes=[int])(X, self.default)

--- a/sklego/preprocessing/identitytransformer.py
+++ b/sklego/preprocessing/identitytransformer.py
@@ -1,38 +1,69 @@
 from sklearn.base import BaseEstimator, TransformerMixin
-
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
 
 
 class IdentityTransformer(BaseEstimator, TransformerMixin):
-    """
-    The identity transformer returns what it is fed. Does not apply anything useful.
+    """The `IdentityTransformer` returns what it is fed. Does not apply any transformation.
+
     The reason for having it is because you can build more expressive pipelines.
 
-    :type check_X: bool, optional, default=False
-    :param check_X: Whether to validate X to be non-empty 2D array of finite values
-                    and attempt to cast X to float.
-                    If disabled, the model/pipeline is expected to handle e.g. missing,
-                    non-numeric, or non-finite values.
+    Parameters
+    ----------
+    check_X : bool, default=False
+        Whether to validate `X` to be non-empty 2D array of finite values and attempt to cast `X` to float.
+        If disabled, the model/pipeline is expected to handle e.g. missing, non-numeric, or non-finite values.
+
+    Attributes
+    ----------
+    shape_ : tuple[int,...]
+        The shape of the input data.
     """
-    def __init__(
-        self,
-        check_X: bool = False
-    ):
+
+    def __init__(self, check_X: bool = False):
         self.check_X = check_X
 
     def fit(self, X, y=None):
-        """'Fits' the estimator."""
+        """Check the input data if `check_X` is enabled and and records its shape.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to fit.
+        y : array-like of shape (n_samples,), default=None
+            Ignored, present for compatibility.
+
+        Returns
+        -------
+        self : IdentityTransformer
+            The fitted transformer.
+        """
         if self.check_X:
             X = check_array(X, copy=True, estimator=self)
         self.shape_ = X.shape
         return self
 
     def transform(self, X):
-        """'Applies' the estimator."""
+        """Performs identity "transformation" on `X` - which is no transformation at all.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input data.
+
+        Returns
+        -------
+        array-like of shape (n_samples, n_features)
+            Unchanged input data.
+
+        Raises
+        ------
+        ValueError
+            If the number of columns from `X` differs from the number of columns when fitting.
+        """
         if self.check_X:
             X = check_array(X, copy=True, estimator=self)
-        check_is_fitted(self, 'shape_')
+        check_is_fitted(self, "shape_")
         if X.shape[1] != self.shape_[1]:
             raise ValueError(f"Wrong shape is passed to transform. Trained on {self.shape_[1]} cols got {X.shape[1]}")
         return X

--- a/sklego/preprocessing/outlier_remover.py
+++ b/sklego/preprocessing/outlier_remover.py
@@ -1,20 +1,26 @@
 from sklearn import clone
 from sklearn.base import BaseEstimator
-from sklearn.utils.validation import (
-    check_is_fitted,
-    check_array,
-)
+from sklearn.utils.validation import check_array, check_is_fitted
 
 from sklego.common import TrainOnlyTransformerMixin
 
 
 class OutlierRemover(TrainOnlyTransformerMixin, BaseEstimator):
-    """
-    Removes outliers (train-time only) using the supplied removal model.
+    """The `OutlierRemover` transformer removes outliers (train-time only) using the supplied removal model. The
+    removal model should implement `.fit()` and `.predict()` methods.
 
-    :param outlier_detector: must implement `fit` and `predict` methods
-    :param refit: If True, fits the estimator during pipeline.fit().
+    Parameters
+    ----------
+    outlier_detector : object
+        An outlier detector that implements `.fit()` and `.predict()` methods.
+    refit : bool, default=True
+        If True, fits the estimator during `pipeline.fit()`. If False, the estimator is not fitted during
+        `pipeline.fit()`.
 
+    Attributes
+    ----------
+    estimator_ : object
+        The fitted outlier detector.
     """
 
     def __init__(self, outlier_detector, refit=True):
@@ -23,6 +29,20 @@ class OutlierRemover(TrainOnlyTransformerMixin, BaseEstimator):
         self.estimator_ = None
 
     def fit(self, X, y=None):
+        """Fit the estimator on training data `X` and `y` by fitting the underlying outlier detector if `refit` is True.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training data.
+        y : array-like of shape (n_samples,), default=None
+            Target values.
+
+        Returns
+        -------
+        self : OutlierRemover
+            The fitted transformer.
+        """
         self.estimator_ = clone(self.outlier_detector)
         if self.refit:
             super().fit(X, y)
@@ -30,6 +50,18 @@ class OutlierRemover(TrainOnlyTransformerMixin, BaseEstimator):
         return self
 
     def transform_train(self, X):
+        """Removes outliers from `X` using the fitted estimator.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data for which the outliers will be removed.
+
+        Returns
+        -------
+        np.ndarray of shape (n_not_outliers, n_features)
+            The data with the outliers removed, where `n_not_outliers = n_samples - n_outliers`.
+        """
         check_is_fitted(self, "estimator_")
         predictions = self.estimator_.predict(X)
         check_array(predictions, estimator=self.outlier_detector, ensure_2d=False)

--- a/sklego/preprocessing/pandastransformers.py
+++ b/sklego/preprocessing/pandastransformers.py
@@ -6,68 +6,104 @@ from sklego.common import as_list
 
 
 class ColumnDropper(BaseEstimator, TransformerMixin):
-    """
-    Allows dropping specific columns from a pandas DataFrame by name. Can be useful in a sklearn Pipeline.
+    """The `ColumnDropper` transformer allows dropping specific columns from a pandas DataFrame by name.
+    Can be useful in a sklearn Pipeline.
 
-    :param columns: column name ``str`` or list of column names to be selected
+    Parameters
+    ----------
+    columns : str | list[str]
+        Column name(s) to be selected.
 
-    .. note::
-        Raises a ``TypeError`` if input provided is not a DataFrame
+    Attributes
+    ----------
+    feature_names_ : list[str]
+        The names of the features to keep during transform.
 
-        Raises a ``ValueError`` if columns provided are not in the input DataFrame
+    Examples
+    --------
+    ```py
+    # Selecting a single column from a pandas DataFrame
+    import pandas as pd
+    from sklego.preprocessing import ColumnDropper
 
-    :Example:
-
-    >>> # Selecting a single column from a pandas DataFrame
-    >>> import pandas as pd
-    >>> df = pd.DataFrame({
-    ...     'name': ['Swen', 'Victor', 'Alex'],
-    ...     'length': [1.82, 1.85, 1.80],
-    ...     'shoesize': [42, 44, 45]
-    ... })
-    >>> ColumnDropper(['name']).fit_transform(df)
+    df = pd.DataFrame({
+        "name": ["Swen", "Victor", "Alex"],
+        "length": [1.82, 1.85, 1.80],
+        "shoesize": [42, 44, 45]
+    })
+    ColumnDropper(["name"]).fit_transform(df)
+    '''
        length  shoesize
     0    1.82        42
     1    1.85        44
     2    1.80        45
+    '''
 
-    >>> # Selecting multiple columns from a pandas DataFrame
-    >>> ColumnDropper(['length', 'shoesize']).fit_transform(df)
+    # Selecting multiple columns from a pandas DataFrame
+    ColumnDropper(["length", "shoesize"]).fit_transform(df)
+    '''
          name
     0    Swen
     1  Victor
     2    Alex
+    '''
 
+    # Selecting non-existent columns returns in a KeyError
+    ColumnDropper(["weight"]).fit_transform(df)
+    # Traceback (most recent call last):
+    #     ...
+    # KeyError: "['weight'] column(s) not in DataFrame"
 
-    >>> # Selecting non-existent columns returns in a KeyError
-    >>> ColumnDropper(['weight']).fit_transform(df)
-    Traceback (most recent call last):
-        ...
-    KeyError: "['weight'] column(s) not in DataFrame"
+    # How to use the ColumnSelector in a sklearn Pipeline
+    from sklearn.pipeline import Pipeline
+    from sklearn.preprocessing import StandardScaler
+    pipe = Pipeline([
+        ("select", ColumnDropper(["name", "shoesize"])),
+        ("scale", StandardScaler()),
+    ])
+    pipe.fit_transform(df)
+    # array([[-0.16222142],
+    #        [ 1.29777137],
+    #        [-1.13554995]])
+    ```
 
-    >>> # How to use the ColumnSelector in a sklearn Pipeline
-    >>> from sklearn.pipeline import Pipeline
-    >>> from sklearn.preprocessing import StandardScaler
-    >>> pipe = Pipeline([
-    ...     ('select', ColumnDropper(['name', 'shoesize'])),
-    ...     ('scale', StandardScaler()),
-    ... ])
-    >>> pipe.fit_transform(df)
-    array([[-0.16222142],
-           [ 1.29777137],
-           [-1.13554995]])
+    !!! warning
+
+        - Raises a `TypeError` if input provided is not a DataFrame.
+        - Raises a `ValueError` if columns provided are not in the input DataFrame.
     """
 
     def __init__(self, columns: list):
         self.columns = columns
 
     def fit(self, X, y=None):
-        """
-        Checks 1) if input is a DataFrame, and 2) if column names are in this DataFrame
+        """Fit the transformer by storing the column names to keep during `.transform()` step.
 
-        :param X: ``pd.DataFrame`` on which we apply the column selection
-        :param y: ``pd.Series`` labels for X. unused for column selection
-        :returns: ``ColumnSelector`` object.
+        Checks:
+
+        1. If input is a `pd.DataFrame` object
+        2. If column names are in such DataFrame
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            The data on which we apply the column selection.
+        y : pd.Series, default=None
+            Ignored, present for compatibility.
+
+        Returns
+        -------
+        self : ColumnDropper
+            The fitted transformer.
+
+        Raises
+        ------
+        TypeError
+            If `X` is not a `pd.DataFrame` object.
+        KeyError
+            If one or more of the columns provided doesn't exist in the input DataFrame.
+        ValueError
+            If dropping the specified columns would result in an empty output DataFrame.
         """
         self.columns_ = as_list(self.columns)
         self._check_X_for_type(X)
@@ -77,10 +113,22 @@ class ColumnDropper(BaseEstimator, TransformerMixin):
         return self
 
     def transform(self, X):
-        """Returns a pandas DataFrame with only the specified columns
+        """Returns a pandas DataFrame with only the specified columns.
 
-        :param X: ``pd.DataFrame`` on which we apply the column selection
-        :returns: ``pd.DataFrame`` with only the selected columns
+        Parameters
+        ----------
+        X : pd.DataFrame
+            The data on which we apply the column selection.
+
+        Returns
+        -------
+        pd.DataFrame
+            The data with the specified columns dropped.
+
+        Raises
+        ------
+        TypeError
+            If `X` is not a `pd.DataFrame` object.
         """
         check_is_fitted(self, ["feature_names_"])
         self._check_X_for_type(X)
@@ -89,14 +137,13 @@ class ColumnDropper(BaseEstimator, TransformerMixin):
         return X
 
     def get_feature_names(self):
+        """Alias for `.feature_names_` attribute"""
         return self.feature_names_
 
     def _check_column_length(self):
         """Check if all columns are dropped"""
         if len(self.feature_names_) == 0:
-            raise ValueError(
-                f"Dropping {self.columns_} would result in an empty output DataFrame"
-            )
+            raise ValueError(f"Dropping {self.columns_} would result in an empty output DataFrame")
 
     def _check_column_names(self, X):
         """Check if one or more of the columns provided doesn't exist in the input DataFrame"""
@@ -112,11 +159,30 @@ class ColumnDropper(BaseEstimator, TransformerMixin):
 
 
 class PandasTypeSelector(BaseEstimator, TransformerMixin):
-    """
-    Select columns in a pandas dataframe based on their dtype
+    """The `PandasTypeSelector` transformer allows to select columns in a pandas DataFrame based on their type.
+    Can be useful in a sklearn Pipeline.
 
-    :param include: types to be included in the dataframe
-    :param exclude: types to be excluded in the dataframe
+    It uses
+    [pandas.DataFrame.select_dtypes](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.select_dtypes.html)
+    method.
+
+    Parameters
+    ----------
+    include : scalar or list-like
+        Column type(s) to be selected
+    exclude : scalar or list-like
+        Column type(s) to be excluded from selection
+
+    Attributes
+    ----------
+    feature_names_ : list[str]
+        The names of the features to keep during transform.
+    X_dtypes_ : pd.Series
+        The dtypes of the columns in the input DataFrame.
+
+    !!! warning
+
+        Raises a `TypeError` if input provided is not a DataFrame.
     """
 
     def __init__(self, include=None, exclude=None):
@@ -124,16 +190,30 @@ class PandasTypeSelector(BaseEstimator, TransformerMixin):
         self.exclude = exclude
 
     def fit(self, X, y=None):
-        """
-        Saves the column names for check during transform
-        :param X: pandas dataframe to select dtypes out of
-        :param y: not used in this class
+        """Fit the transformer by saving the column names to keep during transform.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            The data on which we apply the column selection.
+        y : pd.Series, default=None
+            Ignored, present for compatibility.
+
+        Returns
+        -------
+        self : PandasTypeSelector
+            The fitted transformer.
+
+        Raises
+        ------
+        TypeError
+            If `X` is not a `pd.DataFrame` object.
+        ValueError
+            If provided type(s) results in empty dataframe.
         """
         self._check_X_for_type(X)
         self.X_dtypes_ = X.dtypes
-        self.feature_names_ = list(
-            X.select_dtypes(include=self.include, exclude=self.exclude).columns
-        )
+        self.feature_names_ = list(X.select_dtypes(include=self.include, exclude=self.exclude).columns)
 
         if len(self.feature_names_) == 0:
             raise ValueError("Provided type(s) results in empty dataframe")
@@ -141,12 +221,28 @@ class PandasTypeSelector(BaseEstimator, TransformerMixin):
         return self
 
     def get_feature_names(self, *args, **kwargs):
+        """Alias for `.feature_names_` attribute"""
         return self.feature_names_
 
     def transform(self, X):
-        """
-        Transforms pandas dataframe by (de)selecting columns based on their dtype
-        :param X: pandas dataframe to select dtypes for
+        """Returns a pandas DataFrame with columns (de)selected based on their dtype.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            The data to select dtype for.
+
+        Returns
+        -------
+        pd.DataFrame
+            The data with the specified columns selected.
+
+        Raises
+        ------
+        TypeError
+            If `X` is not a `pd.DataFrame` object.
+        ValueError
+            If column dtypes were not equal during fit and transform.
         """
         check_is_fitted(self, ["X_dtypes_", "feature_names_"])
 
@@ -174,55 +270,72 @@ class PandasTypeSelector(BaseEstimator, TransformerMixin):
 
 
 class ColumnSelector(BaseEstimator, TransformerMixin):
-    """
-    Allows selecting specific columns from a pandas DataFrame by name. Can be useful in a sklearn Pipeline.
+    """The `ColumnSelector` transformer allows selecting specific columns from a pandas DataFrame by name.
+    Can be useful in a sklearn Pipeline.
 
-    :param columns: column name ``str`` or list of column names to be selected
+    Parameters
+    ----------
+    columns : str | list[str]
+        Column name(s) to be selected.
 
-    .. note::
-        Raises a ``TypeError`` if input provided is not a DataFrame
+    Attributes
+    ----------
+    columns_ : list[str]
+        The names of the features to keep during transform.
 
-        Raises a ``ValueError`` if columns provided are not in the input DataFrame
+    Examples
+    --------
+    ```py
+    # Selecting a single column from a pandas DataFrame
+    import pandas as pd
+    from sklego.preprocessing import ColumnSelector
 
-    :Example:
-
-    >>> # Selecting a single column from a pandas DataFrame
-    >>> import pandas as pd
-    >>> df = pd.DataFrame({
-    ...     'name': ['Swen', 'Victor', 'Alex'],
-    ...     'length': [1.82, 1.85, 1.80],
-    ...     'shoesize': [42, 44, 45]
-    ... })
-    >>> ColumnSelector(['length']).fit_transform(df)
-       length
+    df = pd.DataFrame({
+        "name": ["Swen", "Victor", "Alex"],
+        "length": [1.82, 1.85, 1.80],
+        "shoesize": [42, 44, 45]
+    })
+    ColumnSelector(["length"]).fit_transform(df)
+    '''
+        length
     0    1.82
     1    1.85
     2    1.80
+    '''
 
-    >>> # Selecting multiple columns from a pandas DataFrame
-    >>> ColumnSelector(['length', 'shoesize']).fit_transform(df)
+    # Selecting multiple columns from a pandas DataFrame
+    ColumnSelector(["length", "shoesize"]).fit_transform(df)
+    '''
        length  shoesize
     0    1.82        42
     1    1.85        44
     2    1.80        45
+    '''
 
-    >>> # Selecting non-existent columns returns in a KeyError
-    >>> ColumnSelector(['weight']).fit_transform(df)
-    Traceback (most recent call last):
-        ...
-    KeyError: "['weight'] column(s) not in DataFrame"
+    # Selecting non-existent columns returns in a KeyError
+    ColumnSelector(["weight"]).fit_transform(df)
+    # Traceback (most recent call last):
+    #     ...
+    # KeyError: "['weight'] column(s) not in DataFrame"
 
-    >>> # How to use the ColumnSelector in a sklearn Pipeline
-    >>> from sklearn.pipeline import Pipeline
-    >>> from sklearn.preprocessing import StandardScaler
-    >>> pipe = Pipeline([
-    ...     ('select', ColumnSelector(['length'])),
-    ...     ('scale', StandardScaler()),
-    ... ])
-    >>> pipe.fit_transform(df)
-    array([[-0.16222142],
-           [ 1.29777137],
-           [-1.13554995]])
+    # How to use the ColumnSelector in a sklearn Pipeline
+    from sklearn.pipeline import Pipeline
+    from sklearn.preprocessing import StandardScaler
+    pipe = Pipeline([
+        ("select", ColumnSelector(["length"])),
+        ("scale", StandardScaler()),
+    ])
+    pipe.fit_transform(df)
+    # array([[-0.16222142],
+    #        [ 1.29777137],
+    #        [-1.13554995]])
+    ```
+
+    !!! warning
+
+        Raises a `TypeError` if input provided is not a DataFrame.
+
+        Raises a `ValueError` if columns provided are not in the input DataFrame.
     """
 
     def __init__(self, columns: list):
@@ -230,12 +343,33 @@ class ColumnSelector(BaseEstimator, TransformerMixin):
         self.columns = columns
 
     def fit(self, X, y=None):
-        """
-        Checks 1) if input is a DataFrame, and 2) if column names are in this DataFrame
+        """Fit the transformer by storing the column names to keep during transform.
 
-        :param X: ``pd.DataFrame`` on which we apply the column selection
-        :param y: ``pd.Series`` labels for X. unused for column selection
-        :returns: ``ColumnSelector`` object.
+        Checks:
+
+        1. If input is a `pd.DataFrame` object
+        2. If column names are in such DataFrame
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            The data on which we apply the column selection.
+        y : pd.Series, default=None
+            Ignored, present for compatibility.
+
+        Returns
+        -------
+        self : ColumnSelector
+            The fitted transformer.
+
+        Raises
+        ------
+        TypeError
+            If `X` is not a `pd.DataFrame` object.
+        KeyError
+            If one or more of the columns provided doesn't exist in the input DataFrame.
+        ValueError
+            If dropping the specified columns would result in an empty output DataFrame.
         """
         self.columns_ = as_list(self.columns)
         self._check_X_for_type(X)
@@ -244,10 +378,22 @@ class ColumnSelector(BaseEstimator, TransformerMixin):
         return self
 
     def transform(self, X):
-        """Returns a pandas DataFrame with only the specified columns
+        """Returns a pandas DataFrame with only the specified columns.
 
-        :param X: ``pd.DataFrame`` on which we apply the column selection
-        :returns: ``pd.DataFrame`` with only the selected columns
+        Parameters
+        ----------
+        X : pd.DataFrame
+            The data on which we apply the column selection.
+
+        Returns
+        -------
+        pd.DataFrame
+            The data with the specified columns dropped.
+
+        Raises
+        ------
+        TypeError
+            If `X` is not a `pd.DataFrame` object.
         """
         self._check_X_for_type(X)
         if self.columns:
@@ -255,14 +401,13 @@ class ColumnSelector(BaseEstimator, TransformerMixin):
         return X
 
     def get_feature_names(self):
+        """Alias for `.columns_` attribute"""
         return self.columns_
 
     def _check_column_length(self):
         """Check if no column is selected"""
         if len(self.columns_) == 0:
-            raise ValueError(
-                "Expected columns to be at least of length 1, found length of 0 instead"
-            )
+            raise ValueError("Expected columns to be at least of length 1, found length of 0 instead")
 
     def _check_column_names(self, X):
         """Check if one or more of the columns provided doesn't exist in the input DataFrame"""

--- a/sklego/preprocessing/patsytransformer.py
+++ b/sklego/preprocessing/patsytransformer.py
@@ -1,17 +1,26 @@
 import numpy as np
-from patsy import dmatrix, build_design_matrices, PatsyError
+from patsy import PatsyError, build_design_matrices, dmatrix
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
 
 class PatsyTransformer(TransformerMixin, BaseEstimator):
-    """
-    The patsy transformer offers a method to select the right columns
-    from a dataframe as well as a DSL for transformations. It is inspired
-    from R formulas.
-    This is can be useful as a first step in the pipeline.
-    :param formula: a patsy-compatible formula
-    :return_type: Either "matrix" or "dataframe", passed on to patsy
+    """The `PatsyTransformer` offers a method to select the right columns from a dataframe as well as a DSL for
+    transformations.
+
+    It is inspired from R formulas. This is can be useful as a first step in the pipeline.
+
+    Parameters
+    ----------
+    formula : str
+        A patsy-compatible formula.
+    return_type : Literal["matrix", "dataframe"], default="matrix"
+        Either "matrix" or "dataframe", passed on to patsy.
+
+    Attributes
+    ----------
+    design_info_ : [patsy.DesignInfo](https://patsy.readthedocs.io/en/latest/API-reference.html#patsy.DesignInfo)
+        A DesignInfo object holds metadata about a design matrix.
     """
 
     def __init__(self, formula, return_type="matrix"):
@@ -19,27 +28,45 @@ class PatsyTransformer(TransformerMixin, BaseEstimator):
         self.return_type = return_type
 
     def fit(self, X, y=None):
-        """Fits the estimator"""
+        """Fits the transformer on input data `X` by constructing a design matrix given the `formula`.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to fit.
+        y : array-like of shape (n_samples,), default=None
+            Ignored, present for compatibility.
+
+        Returns
+        -------
+        self : PatsyTransformer
+            The fitted transformer.
+        """
         X_ = dmatrix(self.formula, X, NA_action="raise", return_type=self.return_type)
 
-        # check the number of observations hasn't changed. This ought not to
-        # be necessary given NA_action='raise' above but just to be safe
+        # check the number of observations hasn't changed. This ought not to be necessary given NA_action='raise' above
+        # but just to be safe
         assert np.array(X_).shape[0] == np.array(X).shape[0]
         self.design_info_ = X_.design_info
         return self
 
     def transform(self, X):
-        """
-        Applies the formula to the matrix/dataframe X.
+        """Transform `X` by applying the fitted formula.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to transform.
 
         Returns
-        - A patsy.DesignMatrix, if return_type="matrix" (the default)
-        - A pandas.DataFrame, if return_type="dataframe"
+        -------
+        patsy.DesignMatrix | pd.DataFrame
+
+            - DesignMatrix if return_type="matrix" (the default)
+            - pd.DataFrame if return_type="dataframe"
         """
         check_is_fitted(self, "design_info_")
         try:
-            return build_design_matrices(
-                [self.design_info_], X, return_type=self.return_type
-            )[0]
+            return build_design_matrices([self.design_info_], X, return_type=self.return_type)[0]
         except PatsyError as e:
             raise RuntimeError from e

--- a/sklego/preprocessing/randomadder.py
+++ b/sklego/preprocessing/randomadder.py
@@ -1,16 +1,69 @@
 from sklearn.base import BaseEstimator
 from sklearn.utils import check_array, check_X_y
-from sklearn.utils.validation import FLOAT_DTYPES, check_random_state, check_is_fitted
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_random_state
 
 from sklego.common import TrainOnlyTransformerMixin
 
 
 class RandomAdder(TrainOnlyTransformerMixin, BaseEstimator):
+    """The `RandomAdder` transformer adds random noise to the input data.
+
+    This class is designed to be used during the training phase and not for transforming test data.
+    Noise added is sampled from a normal distribution with mean 0 and standard deviation `noise`.
+
+    Parameters
+    ----------
+    noise : float, default=1.0
+        The standard deviation of the normal distribution from which the noise is sampled.
+    random_state : int | None
+        The seed used by the random number generator.
+
+    Attributes
+    ----------
+    dim_ : int
+        Number of features seen during `fit`.
+
+    Examples
+    --------
+    ```py
+    from sklearn.pipeline import Pipeline
+    from sklearn.linear_model import LinearRegression
+    from sklego.preprocessing import RandomAdder
+
+    # Create a pipeline with the RandomAdder and a LinearRegression model
+    pipeline = Pipeline([
+        ('random_adder', RandomAdder(noise=0.5, random_state=42)),
+        ('linear_regression', LinearRegression())
+    ])
+
+    # Fit the pipeline with training data
+    pipeline.fit(X_train, y_train)
+
+    # Use the fitted pipeline to make predictions
+    y_pred = pipeline.predict(X_test)
+    ```
+    """
+
     def __init__(self, noise=1, random_state=None):
         self.noise = noise
         self.random_state = random_state
 
     def fit(self, X, y):
+        """Fit the transformer on training data `X` and `y` by checking the input data and record the number of
+        input features.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training data.
+        y : array-like of shape (n_samples,)
+            Target values.
+
+        Returns
+        -------
+        self : RandomAdder
+            The fitted transformer.
+        """
         super().fit(X, y)
         X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         self.dim_ = X.shape[1]
@@ -18,6 +71,18 @@ class RandomAdder(TrainOnlyTransformerMixin, BaseEstimator):
         return self
 
     def transform_train(self, X):
+        r"""Transform training data by adding random noise sampled from $N(0, \text{noise})$.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data for which the noise will be added.
+
+        Returns
+        -------
+        np.ndarray of shape (n_samples, n_features)
+            The data with the noise added.
+        """
         rs = check_random_state(self.random_state)
         check_is_fitted(self, ["dim_"])
 

--- a/sklego/preprocessing/repeatingbasis.py
+++ b/sklego/preprocessing/repeatingbasis.py
@@ -6,42 +6,44 @@ from sklearn.utils.validation import check_is_fitted
 
 
 class RepeatingBasisFunction(TransformerMixin, BaseEstimator):
+    """The `RepeatingBasisFunction` transformer is designed to be used when the input data has a circular nature.
+
+    For example, for days of the week you might face the problem that, conceptually, day 7 is as close to day 6 as it is
+    to day 1. While numerically their distance is different.
+
+    This transformer remedies that problem. The transformer selects a column and transforms it with a given number of
+    repeating (radial) basis functions.
+
+    Radial basis functions are bell-curve shaped functions which take the original data as input. The basis functions
+    are equally spaced over the input range. The key feature of repeating basis functions is that they are continuous
+    when moving from the max to the min of the input range. As a result these repeating basis functions can capture how
+    close each datapoint is to the center of each repeating basis function, even when the input data has a circular
+    nature.
+
+    Parameters
+    ----------
+    column : int | str, default=0
+        Index or column name of the data to transform. Integers are interpreted as positional columns, while
+        strings can reference DataFrame columns by name.
+    remainder : Literal["drop", "passthrough"], default="drop"
+        By default, only the specified column is transformed, and the non-specified columns are dropped.
+        By specifying `remainder="passthrough"`, all remaining columns will be automatically passed through.
+        This subset of columns is concatenated with the output of the transformer.
+    n_periods : int, default=12
+        Number of basis functions to create, i.e., the number of columns that will exit the transformer.
+    input_range : Tuple[float, float] | List[float] | None, default=None
+        The values at which the data repeats itself. For example, for days of the week this is (1,7).
+        If `input_range=None` it is inferred from the training data.
+    width : float, default=1.0.
+        Determines the width of the radial basis functions.
+
+    Attributes
+    ----------
+    pipeline_ : ColumnTransformer
+        Fitted `ColumnTransformer` object used to transform data with repeating basis functions.
     """
-    This is a transformer for features with some form of circularity.
-    E.g. for days of the week you might face the problem that, conceptually, day 7 is as
-    close to day 6 as it is to day 1. While numerically their distance is different.
-    This transformer remedies that problem.
-    The transformer selects a column and transforms it with a given number of repeating
-    (radial) basis functions. Radial basis functions are bell-curve shaped functions
-    which take the original data as input. The basis functions are equally spaced over
-    the input range. The key feature of repeating basis functions is that they are
-    continuous when moving from the max to the min of the input range. As a result these
-    repeating basis functions can capture how close each datapoint is to the center of
-    each repeating basis function, even when the input data has a circular nature.
 
-    :type column: int or list, default=0
-    :param column: Indexes the data on its second axis. Integers are interpreted as
-        positional columns, while strings can reference DataFrame columns by name.
-
-    :type remainder: {'drop', 'passthrough'}, default="drop"
-    :param remainder: By default, only the specified column is transformed, and the
-        non-specified columns are dropped. (default of ``'drop'``). By specifying
-        ``remainder='passthrough'``, all remaining columns will be automatically passed
-        through. This subset of columns is concatenated with the output of the transformer.
-
-    :type n_periods: int, default=12
-    :param n_periods: number of basis functions to create, i.e., the number of columns that
-        will exit the transformer.
-
-    :type input_range: tuple or None, default=None
-    :param input_range: the values at which the data repeats itself. For example, for days of
-        the week this is (1,7). If input_range=None it is inferred from the training data.
-
-    :type width: float, default=1.
-    :param width: determines the width of the radial basis functions.
-    """
-
-    def __init__(self, column=0, remainder="drop", n_periods=12, input_range=None, width=1.):
+    def __init__(self, column=0, remainder="drop", n_periods=12, input_range=None, width=1.0):
         self.column = column
         self.remainder = remainder
         self.n_periods = n_periods
@@ -49,12 +51,29 @@ class RepeatingBasisFunction(TransformerMixin, BaseEstimator):
         self.width = width
 
     def fit(self, X, y=None):
+        """Fit `RepeatingBasisFunction` transformer on input data `X`.
+        It uses `sklearn.compose.ColumnTransformer`.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data used to compute the quantiles for capping.
+        y : array-like of shape (n_samples,), default=None
+            Ignored, present for compatibility.
+
+        Returns
+        -------
+        self : RepeatingBasisFunction
+            The fitted transformer.
+        """
         self.pipeline_ = ColumnTransformer(
             [
                 (
                     "repeatingbasis",
                     _RepeatingBasisFunction(
-                        n_periods=self.n_periods, input_range=self.input_range, width=self.width
+                        n_periods=self.n_periods,
+                        input_range=self.input_range,
+                        width=self.width,
                     ),
                     [self.column],
                 )
@@ -67,17 +86,67 @@ class RepeatingBasisFunction(TransformerMixin, BaseEstimator):
         return self
 
     def transform(self, X):
+        """Transform input data `X` with fitted `RepeatingBasisFunction` transformer.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to transform.
+
+        Returns
+        -------
+        X_transformed : array-like of shape (n_samples, n_periods)
+            Transformed data.
+        """
         check_is_fitted(self, ["pipeline_"])
         return self.pipeline_.transform(X)
 
 
 class _RepeatingBasisFunction(TransformerMixin, BaseEstimator):
-    def __init__(self, n_periods: int = 12, input_range=None, width: float = 1.):
+    """Transformer for generating repeating basis functions.
+
+    This transformer generates a set of repeating basis functions for a given input data. Each basis function is
+    defined by its center, and the width of the functions is adjusted based on the number of periods. It is
+    particularly useful in applications where periodic patterns need to be captured.
+
+    Parameters
+    ----------
+    n_periods : int, default=12
+        The number of repeating periods or basis functions to generate.
+    input_range : Tuple[float, float] | List[float] | None, default=None
+        The values at which the data repeats itself. For example, for days of the week this is (1,7).
+        If `input_range=None` it is inferred from the training data.
+    width : float, default=1.0
+        The width of the basis functions. This parameter controls how narrow or wide the basis functions are.
+
+    Attributes
+    ----------
+    bases_ : numpy.ndarray of shape (n_periods,)
+        The centers of the repeating basis functions.
+    width_ : float
+        The adjusted width of the basis functions based on the number of periods and the provided width.
+    """
+
+    def __init__(self, n_periods: int = 12, input_range=None, width: float = 1.0):
         self.n_periods = n_periods
         self.input_range = input_range
         self.width = width
 
     def fit(self, X, y=None):
+        """Fit the transformer to the input data and compute the basis functions.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The input data used to compute the basis functions.
+        y : array-like of shape (n_samples), default=None
+            Ignored, present for compatibility.
+
+        Returns
+        -------
+        self : _RepeatingBasisFunction
+            The fitted transformer.
+        """
         X = check_array(X, estimator=self)
 
         # find min and max for standardization if not given explicitly
@@ -93,6 +162,23 @@ class _RepeatingBasisFunction(TransformerMixin, BaseEstimator):
         return self
 
     def transform(self, X):
+        """Transform the input data into features based on the repeating basis functions.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The input data to be transformed using the basis functions.
+
+        Returns
+        -------
+        array-like of shape (n_samples, n_periods)
+            The transformed data with features generated from the basis functions.
+
+        Raises
+        ------
+        ValueError
+            If X has more than one column, as this transformer only accepts one feature as input.
+        """
         X = check_array(X, estimator=self, ensure_2d=True)
         check_is_fitted(self, ["bases_", "width_"])
         # This transformer only accepts one feature as input
@@ -108,24 +194,59 @@ class _RepeatingBasisFunction(TransformerMixin, BaseEstimator):
         return self._rbf(base_distances)
 
     def _array_base_distance(self, arr: np.ndarray, base: float) -> np.ndarray:
-        """Calculates the distances between all array values and the base,
-        where 0 and 1 are assumed to be at the same position"""
+        """Calculate the distances between all array values and the base, where 0 and 1 are assumed to be at the same
+        positions
+
+        Parameters
+        ----------
+        arr : np.ndarray, shape (n_samples,)
+            The input array for which distances to the base are calculated.
+        base : float
+            The base value to which distances are calculated.
+
+        Returns
+        -------
+        np.ndarray, shape (n_samples,)
+            An array of distances between the values in `arr` and the `base`, with consideration of 0 and 1 as
+            equivalent positions.
+        """
         abs_diff_0 = np.abs(arr - base)
         abs_diff_1 = 1 - abs_diff_0
-        concat = np.concatenate(
-            (abs_diff_0.reshape(-1, 1), abs_diff_1.reshape(-1, 1)), axis=1
-        )
+        concat = np.concatenate((abs_diff_0.reshape(-1, 1), abs_diff_1.reshape(-1, 1)), axis=1)
         final = concat.min(axis=1)
         return final
 
     def _array_bases_distances(self, array, bases):
-        """Calculates the distances between all combinations of array and bases values"""
+        """Calculate distances between all combinations of array and bases values.
+
+        Parameters
+        ----------
+        array : np.ndarray, shape (n_samples,)
+            The input array for which distances to the bases are calculated.
+        bases : np.ndarray, shape (n_bases,)
+            The bases values to which distances are calculated.
+
+        Returns
+        -------
+        np.ndarray, shape (n_samples, n_bases)
+            An array of distances between the elements of 'array' and the specified 'bases'.
+        """
         array = array.reshape(-1, 1)
         bases = bases.reshape(1, -1)
 
-        return np.apply_along_axis(
-            lambda b: self._array_base_distance(array, base=b), axis=0, arr=bases
-        )
+        return np.apply_along_axis(lambda b: self._array_base_distance(array, base=b), axis=0, arr=bases)
 
     def _rbf(self, arr):
+        """Apply the Radial Basis Function (RBF) to the input array.
+
+        Parameters
+        ----------
+        arr : np.ndarray
+            The input array to which the RBF is applied.
+
+        Returns
+        -------
+        np.ndarray
+            An array with the RBF applied to the input array.
+        """
         return np.exp(-((arr / self.width_) ** 2))

--- a/sklego/testing.py
+++ b/sklego/testing.py
@@ -1,8 +1,8 @@
 import itertools as it
 from copy import copy
 
-from sklearn.utils._testing import ignore_warnings
 from sklearn.datasets import make_classification, make_regression
+from sklearn.utils._testing import ignore_warnings
 
 
 @ignore_warnings(category=(DeprecationWarning, FutureWarning))


### PR DESCRIPTION
# Description

This PR aims to refactor all the modules docstring in order to standardize them into numpy style. 
Therefore `numpydoc` dependency and extension has been added as well.

**Remark**: The target building tool is **mkdocs-materials** instead of sphinx, therefore some part will not render properly when tested with sphinx. If the decision is to stick with sphinx, then more changes are necessary.

To check how those would render, I added a minimal (?) **mkdocs.yaml** which reads **mkdocs/** folder containing just a page API rendering.

It can be tested by running the following command:
```console
python -m pip install \
    mkdocs==1.5.3 \
    mkdocs-autorefs==0.5.0 \
    mkdocs-material==9.4.5 \
    mkdocs-material-extensions==1.2 \
    mkdocstrings==0.23.0 \
    mkdocstrings-python==1.7.3 
mkdocs serve
```

**Additional information**

- I tried to keep the original docstrings as much as possible
- In some classes there are example usage but not nearly in the most of them. It would be good for future to add a simple example for each class
- All code changes are _solely_ due to black and isort with line length of 120
