### PR TITLE
Make `umap-learn` dependency optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,10 @@ base_packages = [
     "pandas>=1.1.5",
     "patsy>=0.5.1",
     "Deprecated>=1.2.6",
-    "umap-learn>=0.4.6"
 ]
 cvxpy_packages = ["cvxpy>=1.1.8"]
-all_packages = cvxpy_packages
+umap_packages = ["umap-learn>=0.4.6"]
+all_packages = cvxpy_packages + umap_packages
 
 docs_packages = [
     "sphinx==4.5.0",
@@ -55,6 +55,7 @@ setup(
     extras_require={
         "base": base_packages,
         "cvxpy": cvxpy_packages,
+        "umap": umap_packages,
         "all": all_packages,
         "docs": docs_packages,
         "dev": dev_packages,

--- a/sklego/decomposition/umap_reconstruction.py
+++ b/sklego/decomposition/umap_reconstruction.py
@@ -1,5 +1,11 @@
+try:
+    import umap
+except ImportError:
+    from sklego.notinstalled import NotInstalledPackage
+
+    umap = NotInstalledPackage("umap-learn")
+
 import numpy as np
-import umap
 from sklearn.base import BaseEstimator, OutlierMixin
 from sklearn.utils.validation import check_is_fitted, check_array, FLOAT_DTYPES
 

--- a/sklego/notinstalled.py
+++ b/sklego/notinstalled.py
@@ -1,4 +1,7 @@
-KNOWN_PACKAGES = {"cvxpy": {"version": ">=1.0.24", "extra_name": "cvxpy"}}
+KNOWN_PACKAGES = {
+    "cvxpy": {"version": ">=1.0.24", "extra_name": "cvxpy"},
+    "umap-learn": {"version": ">=0.4.6", "extra_name": "umap"},
+}
 
 
 class NotInstalledPackage:
@@ -28,7 +31,7 @@ class NotInstalledPackage:
                 + f"`python -m pip install scikit-lego[{extra_name}]` or "
                 + "`python -m pip install scikit-lego[all]`. "
                 + "For more information, check the 'Dependency installs' section of the installation docs at "
-                + "https://scikit-lego.readthedocs.io/en/latest/install.html"
+                + "https://scikit-lego.netlify.app/install"
             )
             if extra_name
             else ""


### PR DESCRIPTION
# Description

Makes `umap-learn` dependency optional in the same fashion of how it is done with `cvxpy`.
I will update documentation in the open PR accordingly if and when merged.

# Checklist:

- [X] My code follows the style guidelines (flake8)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (also to the readme.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added tests to check whether the new feature adheres to the sklearn convention
- [X] New and existing unit tests pass locally with my changes

If you feel your PR is ready for a review, ping @koaning or @mbrouns. 
