### PR TITLE
[Feature] `WithoutLiersCV` model selection

### DIFF
--- a/tests/test_model_selection/test_withoutlierscv.py
+++ b/tests/test_model_selection/test_withoutlierscv.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+from sklearn.model_selection import GroupKFold, GroupShuffleSplit, KFold, StratifiedKFold
+
+from sklego.model_selection import WithoutLiersCV
+
+
+@pytest.mark.parametrize(
+    "cv_strategy", [KFold(2), KFold(3, shuffle=True), StratifiedKFold(5), GroupKFold(2), GroupShuffleSplit(3)]
+)
+@pytest.mark.parametrize("anomalous_label", [-1, 1])
+def test_split_without_anomalies(cv_strategy, anomalous_label):
+
+    size = 1000
+
+    X = np.random.randn(size, 3)
+    y = (np.random.randn(size) > 1.5).astype(int)
+    groups = np.random.randint(0, 10, size)
+
+    y[y == 1] = anomalous_label
+
+    cv = WithoutLiersCV(cv_strategy, anomalous_label=anomalous_label)
+
+    for inliner_index, test_index in cv.split(X, y, groups):
+        y_train = y[inliner_index]
+        assert np.all(y_train != anomalous_label)
+
+    assert cv.get_n_splits(X, y, groups) == cv_strategy.get_n_splits(X, y, groups)


### PR DESCRIPTION
# Description

Introduces `WithoutLiersCV` as discussed in #307. To be able to follow different cross validation _strategies_, the idea is to take a CV object as input and exclude the anomalous samples from the training indexes. All the splitting logic is delegated to the cv object.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [X] My code follows the style guidelines (flake8)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (also to the readme.md)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added tests to check whether the new feature adheres to the sklearn convention
- [X] New and existing unit tests pass locally with my changes