### PR TITLE
WIP: unittests speedup

### DIFF
--- a/.github/workflows/schedule-dependencies.yml
+++ b/.github/workflows/schedule-dependencies.yml
@@ -28,4 +28,4 @@ jobs:
     - name: Test with pytest
       run: |
         pip install -e ".[test]"
-        pytest -n 2 tests
+        make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,4 @@ jobs:
         python -m pip install -e ".[test]"
     - name: Test with pytest
       run: |
-        pytest -n 2 tests
+        make test

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ install:
 	pre-commit install
 
 test:
-	pytest --disable-warnings --cov=sklego
+	pytest -n auto --disable-warnings --cov=sklego
 	rm -rf .coverage*
 
 precommit:

--- a/sklego/model_selection.py
+++ b/sklego/model_selection.py
@@ -482,10 +482,7 @@ class GroupTimeSeriesSplit(_BaseKFold):
             Train and test indices of the same fold.
         """
         self._check_for_long_estimated_runtime(groups)
-        (
-            self._first_split_index,
-            self._last_split_index,
-        ) = self._calc_first_and_last_split_index(groups=groups)
+        self._first_split_index, self._last_split_index = self._calc_first_and_last_split_index(groups=groups)
         self._best_splits = self._get_split_indices()
         groups = self._regroup(groups)
         for i in range(self.n_splits):

--- a/tests/test_estimators/test_umap_reconstruction.py
+++ b/tests/test_estimators/test_umap_reconstruction.py
@@ -27,7 +27,7 @@ from tests.conftest import general_checks, nonmeta_checks, outlier_checks, selec
     ),
 )
 def test_estimator_checks(test_fn):
-    outlier_mod = UMAPOutlierDetection(n_components=2, threshold=0.1)
+    outlier_mod = UMAPOutlierDetection(n_components=2, threshold=0.1, n_neighbors=3)
     test_fn(UMAPOutlierDetection.__name__, outlier_mod)
 
 
@@ -38,6 +38,12 @@ def dataset():
 
 
 def test_obvious_usecase(dataset):
-    mod = UMAPOutlierDetection(n_components=2, threshold=7.5, random_state=42, variant="absolute").fit(dataset)
+    mod = UMAPOutlierDetection(
+        n_components=2,
+        threshold=7.5,
+        random_state=42,
+        variant="absolute",
+        n_neighbors=3,
+    ).fit(dataset)
     assert mod.predict([[10] * 10]) == np.array([-1])
     assert mod.predict([[0.01] * 10]) == np.array([1])

--- a/tests/test_model_selection/test_grouptimeseriessplit.py
+++ b/tests/test_model_selection/test_grouptimeseriessplit.py
@@ -68,12 +68,12 @@ def test_split_points_chronological(valid_cv):
 
 @pytest.mark.parametrize("n_splits, n_groups", [(4, 251), (5, 101), (6, 31), (7, 31)])
 def test_user_warning(n_splits, n_groups):
-    groups = list(range(n_groups))
-    X = np.random.randint(1, 10000, size=len(groups))
-    y = np.random.randint(1, 10000, size=len(groups))
+    groups = range(n_groups)
+    X, y = np.random.randint(1, 10000, size=(2, n_groups))
+
     cv = GroupTimeSeriesSplit(n_splits)
     with pytest.warns(UserWarning):
-        cv.split(X, y, groups)
+        cv._check_for_long_estimated_runtime(groups)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

I was playing around for some features and while iterating I was getting bored of waiting for tests.
Thus running `pytest . --durations 30 --disable-warnings` I could get the most time consuming tests.

The code changes keep the same level of coverage but lower the runtime.

I opened a [PR in my own fork](https://github.com/FBruzzesi/scikit-lego/actions/runs/7349185428) to quantify the difference and it is quite nice (4m 14s vs last merge here of 7m 37s). 

I didn't investigate much further, but since it was a bit relevant for me I wanted to share it.


