### PR TITLE
[DOCS] Fix relative paths

### DIFF
--- a/docs/api/decay-functions.md
+++ b/docs/api/decay-functions.md
@@ -22,4 +22,4 @@ These functions are used in the [`DecayEstimator`][decay-estimator] to generate 
         show_root_full_path: true
         show_root_heading: true
 
-[decay-estimator]: /api/meta#sklego.meta.decay_estimator.DecayEstimator
+[decay-estimator]: ../../api/meta#sklego.meta.decay_estimator.DecayEstimator

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,5 +47,5 @@ _ = mod.fit(X, y)
 
 To see more examples, please refer to the [user guide section][user-guide].
 
-[installation-section]: /installation
-[user-guide]: /user-guide/datasets
+[installation-section]: ../installation
+[user-guide]: ../user-guide/datasets

--- a/docs/rstudio.md
+++ b/docs/rstudio.md
@@ -135,8 +135,8 @@ Also, it may be simpler and more preferential to use the [python engine][python-
 
 But you can certainly combine the tools from scikit-lego with your tools in R.
 
-[info-filter-api]: /api/preprocessing#sklego.preprocessing.InformationFilter
-[thresholder-api]: /api/meta/#sklego.meta.thresholder.Thresholder
+[info-filter-api]: ../api/preprocessing#sklego.preprocessing.InformationFilter
+[thresholder-api]: ../api/meta/#sklego.meta.thresholder.Thresholder
 
 [reticulate]: https://github.com/rstudio/reticulate
 [reticulate-install]: https://rstudio.github.io/reticulate/articles/versions.html

--- a/docs/rstudio.md
+++ b/docs/rstudio.md
@@ -136,7 +136,7 @@ Also, it may be simpler and more preferential to use the [python engine][python-
 But you can certainly combine the tools from scikit-lego with your tools in R.
 
 [info-filter-api]: ../api/preprocessing#sklego.preprocessing.InformationFilter
-[thresholder-api]: ../api/meta/#sklego.meta.thresholder.Thresholder
+[thresholder-api]: ../api/meta#sklego.meta.thresholder.Thresholder
 
 [reticulate]: https://github.com/rstudio/reticulate
 [reticulate-install]: https://rstudio.github.io/reticulate/articles/versions.html

--- a/docs/user-guide/cross-validation.md
+++ b/docs/user-guide/cross-validation.md
@@ -127,5 +127,5 @@ To use `GroupTimeSeriesSplit` with sklearn's [GridSearchCV](https://scikit-learn
 --8<-- "docs/_scripts/cross-validation.py:grid-search"
 ```
 
-[time-gap-split-api]: /api/model-selection#sklego.model_selection.TimeGapSplit
-[group-ts-split-api]: /api/model-selection#sklego.model_selection.GroupTimeSeriesSplit
+[time-gap-split-api]: ../../api/model-selection#sklego.model_selection.TimeGapSplit
+[group-ts-split-api]: ../../api/model-selection#sklego.model_selection.GroupTimeSeriesSplit

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -197,14 +197,14 @@ Generate a *very simple* timeseries dataset to play with. The generator assumes 
 
 ![timeseries](../_static/datasets/timeseries.png)
 
-[abalone-api]: /api/datasets#sklego.datasets.load_abalone
-[arrests-api]: /api/datasets#sklego.datasets.load_arrests
-[chicken-api]: /api/datasets#sklego.datasets.load_chicken
-[heroes-api]: /api/datasets#sklego.datasets.load_heroes
-[hearts-api]: /api/datasets#sklego.datasets.load_hearts
-[penguins-api]: /api/datasets#sklego.datasets.load_penguins
-[fetch_creditcard-api]: /api/datasets#sklego.datasets.fetch_creditcard
-[make_simpleseries-api]: /api/datasets#sklego.datasets.make_simpleseries
+[abalone-api]: ../../api/datasets#sklego.datasets.load_abalone
+[arrests-api]: ../../api/datasets#sklego.datasets.load_arrests
+[chicken-api]: ../../api/datasets#sklego.datasets.load_chicken
+[heroes-api]: ../../api/datasets#sklego.datasets.load_heroes
+[hearts-api]: ../../api/datasets#sklego.datasets.load_hearts
+[penguins-api]: ../../api/datasets#sklego.datasets.load_penguins
+[fetch_creditcard-api]: ../../api/datasets#sklego.datasets.fetch_creditcard
+[make_simpleseries-api]: ../../api/datasets#sklego.datasets.make_simpleseries
 
 [heroes]: https://heroesofthestorm.blizzard.com/en-us/
 [fetch-openml-api]: https://scikit-learn.org/stable/modules/generated/sklearn.datasets.fetch_openml.html

--- a/docs/user-guide/debug-pipeline.md
+++ b/docs/user-guide/debug-pipeline.md
@@ -121,5 +121,5 @@ Transformed X:
  [1111. 1111. 1111. 1111. 1111.]]
 ```
 
-[debug-pipe-api]: /api/pipeline#sklego.pipeline.DebugPipeline
+[debug-pipe-api]: ../../api/pipeline#sklego.pipeline.DebugPipeline
 [pipe-api]: https://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html

--- a/docs/user-guide/fairness.md
+++ b/docs/user-guide/fairness.md
@@ -272,10 +272,10 @@ where POS is the subset of the population where `y_true = positive_target`.
 [^1]: M. Zafar et al. (2017), Fairness Constraints: Mechanisms for Fair Classification
 [^2]: M. Hardt, E. Price and N. Srebro (2016), Equality of Opportunity in Supervised Learning
 
-[p-percent-score-api]: /api/metrics#sklego.metrics.p_percent_score
-[equal-opportunity-score-api]: /api/metrics#sklego.metrics.equal_opportunity_score
-[filter-information-api]: /api/preprocessing#sklego.preprocessing.projections.InformationFilter
-[demographic-parity-api]: /api/linear_model#sklego.linear_model.DemographicParityClassifier
-[equal-opportunity-api]: /api/linear_model#sklego.linear_model.EqualOpportunityClassifier
+[p-percent-score-api]: ../../api/metrics#sklego.metrics.p_percent_score
+[equal-opportunity-score-api]: ../../api/metrics#sklego.metrics.equal_opportunity_score
+[filter-information-api]: ../../api/preprocessing#sklego.preprocessing.projections.InformationFilter
+[demographic-parity-api]: ../../api/linear_model#sklego.linear_model.DemographicParityClassifier
+[equal-opportunity-api]: ../../api/linear_model#sklego.linear_model.EqualOpportunityClassifier
 
 [gram–schmidt-process]: https://en.wikipedia.org/wiki/Gram%E2%80%93Schmidt_process

--- a/docs/user-guide/linear-models.md
+++ b/docs/user-guide/linear-models.md
@@ -174,8 +174,8 @@ then around 80% of the data is between these two lines.
 
 ![quantile](../_static/linear-models/quantile-fit.png)
 
-[lowess-api]: /api/linear-model#sklego.linear_model.LowessRegression
-[prob-weight-api]: /api/linear-model#sklego.linear_model.ProbWeightRegression
-[column-selector-api]: /api/preprocessing#sklego.preprocessing.ColumnSelector
-[lad-api]: /api/linear-model#sklego.linear_model.LADRegression
-[quantile-api]: /api/linear-model#sklego.linear_model.QuantileRegression
+[lowess-api]: ../../api/linear-model#sklego.linear_model.LowessRegression
+[prob-weight-api]: ../../api/linear-model#sklego.linear_model.ProbWeightRegression
+[column-selector-api]: ../../api/preprocessing#sklego.preprocessing.ColumnSelector
+[lad-api]: ../../api/linear-model#sklego.linear_model.LADRegression
+[quantile-api]: ../../api/linear-model#sklego.linear_model.QuantileRegression

--- a/docs/user-guide/meta-models.md
+++ b/docs/user-guide/meta-models.md
@@ -214,7 +214,7 @@ The arguments of these functions can be passed along to the `DecayEstimator` cla
 DecayEstimator(..., decay_func="linear", min_value=0.5)
 ```
 
-To see which keyword arguments are available for each decay function, please refer to the [Decay Functions API section][decay-functions]:
+To see which keyword arguments are available for each decay function, please refer to the [Decay Functions API section][decay-functions].
 
 Notice that passing a string to refer to the built-in decays is just a convenience.
 
@@ -381,14 +381,14 @@ The `OutlierClassifier` can be combined with any classification model in the `St
 
 --8<-- "docs/_static/meta-models/outlier-classifier-stacking.html"
 
-[thresholder-api]: /api/meta#sklego.meta.thresholder.Thresholder
-[grouped-predictor-api]: /api/meta#sklego.meta.grouped_predictor.GroupedPredictor
-[grouped-transformer-api]: /api/meta#sklego.meta.grouped_transformer.GroupedTransformer
-[decay-api]: /api/meta#sklego.meta.decay_estimator.DecayEstimator
-[decay-functions]: /api/decay-functions
-[confusion-balancer-api]: /api/meta#sklego.meta.confusion_balancer.ConfusionBalancer
-[zero-inflated-api]: /api/meta#sklego.meta.zero_inflated_regressor.ZeroInflatedRegressor
-[outlier-classifier-api]: /api/meta#sklego.meta.outlier_classifier.OutlierClassifier
+[thresholder-api]: ../../api/meta#sklego.meta.thresholder.Thresholder
+[grouped-predictor-api]: ../../api/meta#sklego.meta.grouped_predictor.GroupedPredictor
+[grouped-transformer-api]: ../../api/meta#sklego.meta.grouped_transformer.GroupedTransformer
+[decay-api]: ../../api/meta#sklego.meta.decay_estimator.DecayEstimator
+[decay-functions]: ../../api/decay-functions
+[confusion-balancer-api]: ../../api/meta#sklego.meta.confusion_balancer.ConfusionBalancer
+[zero-inflated-api]: ../../api/meta#sklego.meta.zero_inflated_regressor.ZeroInflatedRegressor
+[outlier-classifier-api]: ../../api/meta#sklego.meta.outlier_classifier.OutlierClassifier
 
 [standard-scaler-api]: https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.StandardScaler.html
 [stacking-classifier-api]: https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.StackingClassifier.html#sklearn.ensemble.StackingClassifier

--- a/docs/user-guide/mixture-methods.md
+++ b/docs/user-guide/mixture-methods.md
@@ -58,5 +58,5 @@ As a sidenote: this image was generated with some dummy data, but its code can b
     --8<-- "docs/_scripts/mixture-methods.py:outlier-mixture-threshold"
     ```
 
-[gmm-classifier-api]: /api/mixture#sklego.mixture.gmm_classifier.GMMClassifier
-[gmm-outlier-detector-api]: /api/mixture#sklego.mixture.gmm_outlier_detector.GMMOutlierDetector
+[gmm-classifier-api]: ../../api/mixture#sklego.mixture.gmm_classifier.GMMClassifier
+[gmm-outlier-detector-api]: ../../api/mixture#sklego.mixture.gmm_outlier_detector.GMMOutlierDetector

--- a/docs/user-guide/naive-bayes.md
+++ b/docs/user-guide/naive-bayes.md
@@ -37,4 +37,4 @@ We can even zoom in on this second algorithm by having it sample what it believe
 
 ![density](../_static/naive-bayes/model-density.png)
 
-[gaussian-mix-nb-api]: /api/naive-bayes#sklego.naive_bayes.GaussianMixtureNB
+[gaussian-mix-nb-api]: ../../api/naive-bayes#sklego.naive_bayes.GaussianMixtureNB

--- a/docs/user-guide/outliers.md
+++ b/docs/user-guide/outliers.md
@@ -53,7 +53,7 @@ The other parameters in both models are unique to their underlying transformer m
 
 ## Density Based Detection
 
-We've also got a few outlier detection techniques that are density based approaches. You will find a subset documented in the [mixture method section](/user-guide/mixture-methods) but for completeness we will also list them below here as a comparison.
+We've also got a few outlier detection techniques that are density based approaches. You will find a subset documented in the [mixture method section][mixture-method-user-guide] but for completeness we will also list them below here as a comparison.
 
 ### [GMMOutlierDetector][gmm-outlier-api] Demonstration
 
@@ -71,7 +71,7 @@ We've also got a few outlier detection techniques that are density based approac
 
 ![bayesian-gmm-outlier](../_static/outliers/bayesian-gmm-outlier.png)
 
-Note that for these density based approaches the threshold needs to be interpreted differently. If you're interested, you can find more information [here](/user-guide/mixture-methods#detection-details).
+Note that for these density based approaches the threshold needs to be interpreted differently. If you're interested, you can find more information [here][density-based-user-guide].
 
 ## Model Based Outlier Detection
 
@@ -91,11 +91,13 @@ Note that in order to be complaint to the scikit-learn API we require that the `
 
 ![regr-outlier](../_static/outliers/regr-outlier.png)
 
-[pca-outlier-api]: /api/decomposition#sklego.decomposition.pca_reconstruction.PCAOutlierDetection
-[umap-outlier-api]: /api/decomposition#sklego.decomposition.umap_reconstruction.UMAPOutlierDetection.md
-[gmm-outlier-api]: /api/mixture#sklego.mixture.gmm_outlier_detector.GMMOutlierDetector
-[bayesian-gmm-outlier-api]: /api/mixture#sklego.mixture.bayesian_gmm_detector.BayesianGMMOutlierDetector
-[regr-outlier-api]: /api/meta#sklego.meta.regression_outlier_detector.RegressionOutlierDetector
+[pca-outlier-api]: ../../api/decomposition#sklego.decomposition.pca_reconstruction.PCAOutlierDetection
+[umap-outlier-api]: ../../api/decomposition#sklego.decomposition.umap_reconstruction.UMAPOutlierDetection.md
+[gmm-outlier-api]: ../../api/mixture#sklego.mixture.gmm_outlier_detector.GMMOutlierDetector
+[bayesian-gmm-outlier-api]: ../../api/mixture#sklego.mixture.bayesian_gmm_detector.BayesianGMMOutlierDetector
+[regr-outlier-api]: ../../api/meta#sklego.meta.regression_outlier_detector.RegressionOutlierDetector
+[mixture-method-user-guide]: ../../user-guide/mixture-methods
+[density-based-user-guide]: ../../user-guide/mixture-methods#detection-details
 
 [pyod-docs]: https://pyod.readthedocs.io/en/latest/
 [pca-api]: https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html

--- a/docs/user-guide/pandas-pipelines.md
+++ b/docs/user-guide/pandas-pipelines.md
@@ -122,6 +122,6 @@ For example, if we want to log some arbitrary message and the number of unique c
 224     125     8     21     2
 ```
 
-[log-step-api]: /api/pandas_pipeline#sklego.pandas_utils.log_step
-[log-step-extra-api]: /api/pandas_pipeline#sklego.pandas_utils.log_step_extra
+[log-step-api]: ../../api/pandas_pipeline#sklego.pandas_utils.log_step
+[log-step-extra-api]: ../../api/pandas_pipeline#sklego.pandas_utils.log_step_extra
 [method-chaining]: https://tomaugspurger.net/posts/method-chaining/

--- a/docs/user-guide/preprocessing.md
+++ b/docs/user-guide/preprocessing.md
@@ -278,14 +278,14 @@ Now let's see what occurs when we add a constraint that enforces the feature to 
 
 If these features are now passed to a model that supports monotonicity constraints then we can build models with guarantees.
 
-[estimator-transformer-api]: /api/meta#sklego.meta.estimator_transformer.EstimatorTransformer
-[meta-module]: /api/meta
-[id-transformer-api]: /api/preprocessing#sklego.preprocessing.identitytransformer.IdentityTransformer
-[column-capper-api]: /api/preprocessing#sklego.preprocessing.columncapper.ColumnCapper
-[patsy-api]: /api/preprocessing#sklego.preprocessing.patsytransformer.PatsyTransformer
-[rbf-api]: /api/preprocessing#sklego.preprocessing.repeatingbasis.RepeatingBasisFunction
-[interval-encoder-api]: /api/preprocessing#sklego.preprocessing.intervalencoder.IntervalEncoder
-[decay-section]: /user-guide/meta#decayed-estimation
+[estimator-transformer-api]: ../../api/meta#sklego.meta.estimator_transformer.EstimatorTransformer
+[meta-module]: ../../api/meta
+[id-transformer-api]: ../../api/preprocessing#sklego.preprocessing.identitytransformer.IdentityTransformer
+[column-capper-api]: ../../api/preprocessing#sklego.preprocessing.columncapper.ColumnCapper
+[patsy-api]: ../../api/preprocessing#sklego.preprocessing.patsytransformer.PatsyTransformer
+[rbf-api]: ../../api/preprocessing#sklego.preprocessing.repeatingbasis.RepeatingBasisFunction
+[interval-encoder-api]: ../../api/preprocessing#sklego.preprocessing.intervalencoder.IntervalEncoder
+[decay-section]: ../../user-guide/meta#decayed-estimation
 
 [patsy-docs]: https://patsy.readthedocs.io/en/latest/
 [patsy-formulas]: https://patsy.readthedocs.io/en/latest/formulas.html

--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,16 @@
 [![Build status](https://github.com/koaning/scikit-lego/workflows/Unit%20Tests/badge.svg)](https://github.com/{github_id}/{repository}/workflows/{workflow_name}/badge.svg)
-[![Downloads](https://pepy.tech/badge/scikit-lego/month)](https://pepy.tech/project/scikit-lego)
+[![Downloads](https://static.pepy.tech/badge/scikit-lego/month)](https://www.pepy.tech/projects/scikit-lego)
 [![Version](https://img.shields.io/pypi/v/scikit-lego)](https://pypi.org/project/scikit-lego/)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/scikit-lego.svg)](https://anaconda.org/conda-forge/scikit-lego)
 ![](https://img.shields.io/github/license/koaning/scikit-lego)
 ![](https://img.shields.io/pypi/pyversions/scikit-lego)
 ![](https://img.shields.io/github/contributors/koaning/scikit-lego)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![DOI](https://zenodo.org/badge/166836939.svg)](https://zenodo.org/badge/latestdoi/166836939)
 
 # scikit-lego
 
-<a href="https://scikit-lego.readthedocs.io/en/latest/"><img src="images/logo.png" width="35%" height="35%" align="right" /></a>
+<a href="https://koaning.github.io/scikit-lego/"><img src="images/logo.png" width="35%" height="35%" align="right" /></a>
 
 We love scikit learn but very often we find ourselves writing
 custom transformers, metrics and models. The goal of this project
@@ -49,7 +49,7 @@ python setup.py develop
 
 ## Documentation
 
-The documentation can be found [here](https://scikit-lego.netlify.app).
+The documentation can be found [here](https://koaning.github.io/scikit-lego/).
 
 ## Usage
 

--- a/sklego/common.py
+++ b/sklego/common.py
@@ -333,7 +333,7 @@ def sliding_window(sequence, window_size, step_size):
 
     Examples
     --------
-    ```
+    ```py
     list(sliding_window([1, 2, 4, 5], 2, 1))
     # [[1, 2], [2, 4], [4, 5], [5]]
     ```

--- a/sklego/datasets.py
+++ b/sklego/datasets.py
@@ -146,7 +146,7 @@ def load_arrests(return_X_y=False, as_frame=False):
     ```
 
     The dataset was copied from the carData R package
-    ([dataset documentation](http://vincentarelbundock.github.io/Rdatasets/doc/carData/Arrests.html))
+    ([dataset documentation](https://vincentarelbundock.github.io/Rdatasets/doc/carData/Arrests.html))
     and can originally be found in:
 
     - Personal communication from Michael Friendly, York University.

--- a/sklego/linear_model.py
+++ b/sklego/linear_model.py
@@ -238,8 +238,9 @@ class DeadZoneRegressor(BaseEstimator, RegressorMixin):
 
     $$\text{deadzone}(e) =
     \begin{cases}
-    e & \text{if } e > \text{threshold} \text{ and effect="linear"} \\
-    e^2 & \text{if } e > \text{threshold} \text{ and effect="quadratic"} \\
+    1 & \text{if } e > \text{threshold} \text{ & effect="constant"} \\
+    e & \text{if } e > \text{threshold} \text{ & effect="linear"} \\
+    e^2 & \text{if } e > \text{threshold} \text{ & effect="quadratic"} \\
     0 & \text{otherwise}
     \end{cases}
     $$
@@ -638,7 +639,7 @@ class FairClassifier(DemographicParityClassifier):
 
 
 class _DemographicParityClassifier(_FairClassifier):
-    r"""Classifier for Demographic Parity fairness constraint.
+    """Classifier for Demographic Parity fairness constraint.
 
     This classifier extends the `_FairClassifier` and adds a Demographic Parity fairness constraint.
     Demographic Parity ensures that the probability of a positive outcome is the same for all groups defined by

--- a/sklego/meta/confusion_balancer.py
+++ b/sklego/meta/confusion_balancer.py
@@ -14,7 +14,7 @@ class ConfusionBalancer(BaseEstimator, ClassifierMixin, MetaEstimatorMixin):
     class that the underlying model gives. We use these probabilities to attempt a more balanced prediction by averaging
     the correction from the confusion matrix with the original probabilities.
 
-    $$P(\text{class_j}) = \alpha P(\text{model}_j) + (1-\alpha) P(\text{class_j} | \text{model}_j) P(\text{model}_j)$$
+    $$P(\text{class}_j) = \alpha P(\text{model}_j) + (1-\alpha) P(\text{class}_j | \text{model}_j) P(\text{model}_j)$$
 
     Parameters
     ----------

--- a/sklego/preprocessing/projections.py
+++ b/sklego/preprocessing/projections.py
@@ -27,7 +27,7 @@ class OrthogonalTransformer(BaseEstimator, TransformerMixin):
 
     Examples
     --------
-    ```
+    ```py
     from sklearn.datasets import make_regression
     from sklego.preprocessing import OrthogonalTransformer
 


### PR DESCRIPTION
# Description

In the deployed docs in github pages, all relative links are broken. I would imagine that the issue is similar to what happened in #602 .

This PR tries to patch that. 

Most annoying fact is that locally both strategies work.

Edit: Adding screenshot as example:

Clicking the link at https://koaning.github.io/scikit-lego/#usage to open the user guide

![image](https://github.com/koaning/scikit-lego/assets/42817048/742ae6ea-a3c3-4fdf-acf8-04c4429e9e99)

maps to https://koaning.github.io/user-guide/datasets (which is 404) instead of https://koaning.github.io/scikit-lego/user-guide/datasets/