### PR TITLE
`GroupedTransformer` with transformers that use `y`

### DIFF
--- a/sklego/meta/grouped_transformer.py
+++ b/sklego/meta/grouped_transformer.py
@@ -31,10 +31,11 @@ class GroupedTransformer(BaseEstimator, TransformerMixin):
 
     _check_kwargs = {"accept_large_sparse": False}
 
-    def __init__(self, transformer, groups, use_global_model=True):
+    def __init__(self, transformer, groups, use_global_model=True, check_X=True):
         self.transformer = transformer
         self.groups = groups
         self.use_global_model = use_global_model
+        self.check_X = check_X
 
     def __fit_single_group(self, group, X, y=None):
         """Fit transformer to the given group.
@@ -117,11 +118,11 @@ class GroupedTransformer(BaseEstimator, TransformerMixin):
             self.transformers_ = clone(self.transformer).fit(X, y)
             return self
 
-        X_group, X_value = _split_groups_and_values(X, self.groups, **self._check_kwargs)
+        X_group, X_value = _split_groups_and_values(X, self.groups, check_X=self.check_X, **self._check_kwargs)
         self.transformers_ = self.__fit_grouped_transformer(X_group, X_value, y)
 
         if self.use_global_model:
-            self.fallback_ = clone(self.transformer).fit(X_value)
+            self.fallback_ = clone(self.transformer).fit(X_value, y)
 
         return self
 
@@ -157,7 +158,7 @@ class GroupedTransformer(BaseEstimator, TransformerMixin):
                 axis=0,
             )
             .sort_index()
-            .values
+            .to_numpy()
         )
 
     def transform(self, X):

--- a/sklego/meta/grouped_transformer.py
+++ b/sklego/meta/grouped_transformer.py
@@ -19,6 +19,8 @@ class GroupedTransformer(BaseEstimator, TransformerMixin):
         applied to the entire input without grouping.
     use_global_model : bool, default=True
         Whether or not to fall back to a general transformation in case a group is not found during `.transform()`.
+    check_X : bool, default=True
+        Whether or not to check the input data. If False, the checks are delegated to the wrapped estimator.
 
     Attributes
     ----------

--- a/sklego/pipeline.py
+++ b/sklego/pipeline.py
@@ -2,7 +2,6 @@
 Pipelines, variances to the `sklearn.pipeline.Pipeline` object.
 """
 
-
 import logging
 import time
 

--- a/tests/test_meta/test_grouped_transformer.py
+++ b/tests/test_meta/test_grouped_transformer.py
@@ -162,6 +162,7 @@ def test_get_params():
         "transformer": trf,
         "groups": 0,
         "use_global_model": True,
+        "check_X": True,
     }
 
 


### PR DESCRIPTION
# Description

Fixes #459 by passing `y` when fitting the global transformer as well.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the style guidelines (flake8)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (also to the readme.md)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added tests to check whether the new feature adheres to the sklearn convention
- [X] New and existing unit tests pass locally with my changes