### PR TITLE
docs: `ClusterFoldValidation` api

### DIFF
--- a/docs/api/model-selection.md
+++ b/docs/api/model-selection.md
@@ -17,4 +17,4 @@
 
 ## `KlusterFoldValidation`
 
-Prior to `version 0.9.0`, the `ClusterFoldValidation` class was named `KlusterFoldValidation`. The old name is deprecated and will be removed in a future releases.
+Prior to `version 0.8.2`, the `ClusterFoldValidation` class was named `KlusterFoldValidation`. The old name is deprecated and will be removed in a future releases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scikit-lego"
-version = "0.9.0"
+version = "0.8.2"
 description="A collection of lego bricks for scikit-learn pipelines"
 
 license = {file = "LICENSE"}

--- a/sklego/model_selection.py
+++ b/sklego/model_selection.py
@@ -261,7 +261,7 @@ class ClusterFoldValidation:
     """Cross validator that creates folds based on provided cluster method.
     This ensures that data points in the same cluster are not split across different folds.
 
-    !!! info "New in version 0.9.0"
+    !!! info "New in version 0.8.2"
 
     Parameters
     ----------


### PR DESCRIPTION
# Description

While spinning the documentation locally with the latest changes, I noticed that `ClusterFoldValidation` didn't make it into the API section since classes are manually added there.

I also bumped the lib version, as this change in the documentation should appear only once the feature is released.
