### PR TITLE
feat: make ColumnDropper dataframe-agnostic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ maintainers = [
 ]
 
 dependencies = [
+    "narwhals>=0.7.16",
     "pandas>=1.1.5",
     "scikit-learn>=1.0",
     "importlib-metadata >= 1.0; python_version < '3.8'",
@@ -61,6 +62,7 @@ docs = [
 ]
 
 test-dep = [
+    "polars",
     "pytest>=6.2.5",
     "pytest-xdist>=1.34.0",
     "pytest-cov>=2.6.1",
@@ -111,4 +113,3 @@ markers = [
     "formulaic: tests that require formulaic (deselect with '-m \"not formulaic\"')",
     "umap: tests that require umap (deselect with '-m \"not umap\"')"
 ]
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ docs = [
 ]
 
 test-dep = [
-    "polars",
+    "narwhals[polars]",
     "pytest>=6.2.5",
     "pytest-xdist>=1.34.0",
     "pytest-cov>=2.6.1",

--- a/sklego/preprocessing/pandastransformers.py
+++ b/sklego/preprocessing/pandastransformers.py
@@ -22,6 +22,7 @@ class ColumnDropper(BaseEstimator, TransformerMixin):
 
     Notes
     -----
+    Native cross-dataframe support is achieved using [Narwhals](https://narwhals-dev.github.io).
     Supported dataframes are:
 
     - pandas
@@ -30,7 +31,7 @@ class ColumnDropper(BaseEstimator, TransformerMixin):
     - cuDF
 
     See [Narwhals docs](https://narwhals-dev.github.io/narwhals/extending/) for an
-    up-to-date list (and to learn how to add your dataframe library to it!).
+    up-to-date list (and to learn how you can add your dataframe library to it!).
 
     Examples
     --------

--- a/sklego/preprocessing/pandastransformers.py
+++ b/sklego/preprocessing/pandastransformers.py
@@ -29,6 +29,9 @@ class ColumnDropper(BaseEstimator, TransformerMixin):
     - Modin
     - cuDF
 
+    See [Narwhals docs](https://narwhals-dev.github.io/narwhals/extending/) for an
+    up-to-date list (and to learn how to add your dataframe library to it!).
+
     Examples
     --------
     ```py
@@ -132,13 +135,13 @@ class ColumnDropper(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        pd.DataFrame
+        DataFrame
             The data with the specified columns dropped.
 
         Raises
         ------
         TypeError
-            If `X` is not a `pd.DataFrame` object.
+            If `X` is not a supported DataFrame object.
         """
         check_is_fitted(self, ["feature_names_"])
         X = nw.from_native(X)

--- a/sklego/preprocessing/pandastransformers.py
+++ b/sklego/preprocessing/pandastransformers.py
@@ -22,7 +22,9 @@ class ColumnDropper(BaseEstimator, TransformerMixin):
 
     Notes
     -----
-    Native cross-dataframe support is achieved using [Narwhals](https://narwhals-dev.github.io).
+    Native cross-dataframe support is achieved using
+    [Narwhals](https://narwhals-dev.github.io/narwhals/){:target="_blank"}.
+
     Supported dataframes are:
 
     - pandas
@@ -30,8 +32,8 @@ class ColumnDropper(BaseEstimator, TransformerMixin):
     - Modin
     - cuDF
 
-    See [Narwhals docs](https://narwhals-dev.github.io/narwhals/extending/) for an
-    up-to-date list (and to learn how you can add your dataframe library to it!).
+    See [Narwhals docs](https://narwhals-dev.github.io/narwhals/extending/){:target="_blank"} for an up-to-date list
+    (and to learn how you can add your dataframe library to it!).
 
     Examples
     --------
@@ -53,7 +55,7 @@ class ColumnDropper(BaseEstimator, TransformerMixin):
     2    1.80        45
     '''
 
-    # Selecting multiple columns from a pandas DataFrame
+    # Dropping multiple columns from a pandas DataFrame
     ColumnDropper(["length", "shoesize"]).fit_transform(df)
     '''
          name
@@ -62,7 +64,7 @@ class ColumnDropper(BaseEstimator, TransformerMixin):
     2    Alex
     '''
 
-    # Selecting non-existent columns returns in a KeyError
+    # Dropping non-existent columns results in a KeyError
     ColumnDropper(["weight"]).fit_transform(df)
     # Traceback (most recent call last):
     #     ...
@@ -81,10 +83,12 @@ class ColumnDropper(BaseEstimator, TransformerMixin):
     #        [-1.13554995]])
     ```
 
-    !!! warning
-
-        - Raises a `TypeError` if input provided is not a DataFrame.
-        - Raises a `ValueError` if columns provided are not in the input DataFrame.
+    Raises
+    ------
+    TypeError
+        If input provided is not a DataFrame.
+    KeyError
+        If columns provided are not in the input DataFrame.
     """
 
     def __init__(self, columns: list):

--- a/tests/test_preprocessing/test_columndropper.py
+++ b/tests/test_preprocessing/test_columndropper.py
@@ -1,6 +1,8 @@
 import pandas as pd
+import polars as pl
 import pytest
-from pandas.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal as pandas_assert_frame_equal
+from polars.testing import assert_frame_equal as polars_assert_frame_equal
 from sklearn.pipeline import make_pipeline
 
 from sklego.preprocessing import ColumnDropper
@@ -9,6 +11,19 @@ from sklego.preprocessing import ColumnDropper
 @pytest.fixture()
 def df():
     return pd.DataFrame(
+        {
+            "a": [1, 2, 3, 4, 5, 6],
+            "b": [10, 9, 8, 7, 6, 5],
+            "c": ["a", "b", "a", "b", "c", "c"],
+            "d": ["b", "a", "a", "b", "a", "b"],
+            "e": [0, 1, 0, 1, 0, 1],
+        }
+    )
+
+
+@pytest.fixture()
+def df_polars():
+    return pl.DataFrame(
         {
             "a": [1, 2, 3, 4, 5, 6],
             "b": [10, 9, 8, 7, 6, 5],
@@ -29,7 +44,7 @@ def test_drop_two(df):
         }
     )
 
-    assert_frame_equal(result_df, expected_df)
+    pandas_assert_frame_equal(result_df, expected_df)
 
 
 def test_drop_one(df):
@@ -43,7 +58,7 @@ def test_drop_one(df):
         }
     )
 
-    assert_frame_equal(result_df, expected_df)
+    pandas_assert_frame_equal(result_df, expected_df)
 
 
 def test_drop_all(df):
@@ -53,7 +68,7 @@ def test_drop_all(df):
 
 def test_drop_none(df):
     result_df = ColumnDropper([]).fit_transform(df)
-    assert_frame_equal(result_df, df)
+    pandas_assert_frame_equal(result_df, df)
 
 
 def test_drop_not_in_frame(df):
@@ -73,10 +88,23 @@ def test_drop_one_in_pipeline(df):
         }
     )
 
-    assert_frame_equal(result_df, expected_df)
+    pandas_assert_frame_equal(result_df, expected_df)
 
 
 def test_get_feature_names():
     df = pd.DataFrame({"a": [4, 5, 6], "b": ["4", "5", "6"]})
     transformer = ColumnDropper("a").fit(df)
     assert transformer.get_feature_names() == ["b"]
+
+
+def test_drop_two_polars(df_polars):
+    result_df = ColumnDropper(["a", "b"]).fit_transform(df_polars)
+    expected_df = pl.DataFrame(
+        {
+            "c": ["a", "b", "a", "b", "c", "c"],
+            "d": ["b", "a", "a", "b", "a", "b"],
+            "e": [0, 1, 0, 1, 0, 1],
+        }
+    )
+
+    polars_assert_frame_equal(result_df, expected_df)

--- a/tests/test_preprocessing/test_columndropper.py
+++ b/tests/test_preprocessing/test_columndropper.py
@@ -1,110 +1,53 @@
+from contextlib import nullcontext as does_not_raise
+
 import pandas as pd
 import polars as pl
 import pytest
 from pandas.testing import assert_frame_equal as pandas_assert_frame_equal
 from polars.testing import assert_frame_equal as polars_assert_frame_equal
-from sklearn.pipeline import make_pipeline
+from sklearn.pipeline import Pipeline, make_pipeline
 
 from sklego.preprocessing import ColumnDropper
 
 
 @pytest.fixture()
-def df():
-    return pd.DataFrame(
-        {
-            "a": [1, 2, 3, 4, 5, 6],
-            "b": [10, 9, 8, 7, 6, 5],
-            "c": ["a", "b", "a", "b", "c", "c"],
-            "d": ["b", "a", "a", "b", "a", "b"],
-            "e": [0, 1, 0, 1, 0, 1],
-        }
-    )
+def data():
+    return {
+        "a": [1, 2, 3, 4, 5, 6],
+        "b": [10, 9, 8, 7, 6, 5],
+        "c": ["a", "b", "a", "b", "c", "c"],
+        "d": ["b", "a", "a", "b", "a", "b"],
+        "e": [0, 1, 0, 1, 0, 1],
+    }
 
 
-@pytest.fixture()
-def df_polars():
-    return pl.DataFrame(
-        {
-            "a": [1, 2, 3, 4, 5, 6],
-            "b": [10, 9, 8, 7, 6, 5],
-            "c": ["a", "b", "a", "b", "c", "c"],
-            "d": ["b", "a", "a", "b", "a", "b"],
-            "e": [0, 1, 0, 1, 0, 1],
-        }
-    )
+@pytest.mark.parametrize(
+    "frame_func, assert_func",
+    [
+        (pd.DataFrame, pandas_assert_frame_equal),
+        (pl.DataFrame, polars_assert_frame_equal),
+    ],
+)
+@pytest.mark.parametrize(
+    "to_drop, context",
+    [
+        (["e"], does_not_raise()),  # one
+        (["a", "b"], does_not_raise()),  # two
+        ([], does_not_raise()),  # none
+        (["a", "b", "c", "d", "e"], pytest.raises(ValueError)),  # all
+        (["f"], pytest.raises(KeyError)),  # not in data
+    ],
+)
+@pytest.mark.parametrize("wrapper", [lambda x: x, make_pipeline])
+def test_drop(data, frame_func, assert_func, to_drop, context, wrapper):
+    sub_data = {k: v for k, v in data.items() if k not in to_drop}
 
+    with context:
+        transformer = wrapper(ColumnDropper(to_drop))
+        result_df = transformer.fit_transform(frame_func(data))
+        expected_df = frame_func(sub_data)
 
-def test_drop_two(df):
-    result_df = ColumnDropper(["a", "b"]).fit_transform(df)
-    expected_df = pd.DataFrame(
-        {
-            "c": ["a", "b", "a", "b", "c", "c"],
-            "d": ["b", "a", "a", "b", "a", "b"],
-            "e": [0, 1, 0, 1, 0, 1],
-        }
-    )
+        assert_func(result_df, expected_df)
 
-    pandas_assert_frame_equal(result_df, expected_df)
-
-
-def test_drop_one(df):
-    result_df = ColumnDropper(["e"]).fit_transform(df)
-    expected_df = pd.DataFrame(
-        {
-            "a": [1, 2, 3, 4, 5, 6],
-            "b": [10, 9, 8, 7, 6, 5],
-            "c": ["a", "b", "a", "b", "c", "c"],
-            "d": ["b", "a", "a", "b", "a", "b"],
-        }
-    )
-
-    pandas_assert_frame_equal(result_df, expected_df)
-
-
-def test_drop_all(df):
-    with pytest.raises(ValueError):
-        ColumnDropper(["a", "b", "c", "d", "e"]).fit_transform(df)
-
-
-def test_drop_none(df):
-    result_df = ColumnDropper([]).fit_transform(df)
-    pandas_assert_frame_equal(result_df, df)
-
-
-def test_drop_not_in_frame(df):
-    with pytest.raises(KeyError):
-        ColumnDropper(["f"]).fit_transform(df)
-
-
-def test_drop_one_in_pipeline(df):
-    pipe = make_pipeline(ColumnDropper(["e"]))
-    result_df = pipe.fit_transform(df)
-    expected_df = pd.DataFrame(
-        {
-            "a": [1, 2, 3, 4, 5, 6],
-            "b": [10, 9, 8, 7, 6, 5],
-            "c": ["a", "b", "a", "b", "c", "c"],
-            "d": ["b", "a", "a", "b", "a", "b"],
-        }
-    )
-
-    pandas_assert_frame_equal(result_df, expected_df)
-
-
-def test_get_feature_names():
-    df = pd.DataFrame({"a": [4, 5, 6], "b": ["4", "5", "6"]})
-    transformer = ColumnDropper("a").fit(df)
-    assert transformer.get_feature_names() == ["b"]
-
-
-def test_drop_two_polars(df_polars):
-    result_df = ColumnDropper(["a", "b"]).fit_transform(df_polars)
-    expected_df = pl.DataFrame(
-        {
-            "c": ["a", "b", "a", "b", "c", "c"],
-            "d": ["b", "a", "a", "b", "a", "b"],
-            "e": [0, 1, 0, 1, 0, 1],
-        }
-    )
-
-    polars_assert_frame_equal(result_df, expected_df)
+        if not isinstance(transformer, Pipeline):
+            assert transformer.get_feature_names() == list(sub_data.keys())


### PR DESCRIPTION
Hey 👋 I discussed a bit with Francesco, who discussed it with Vincent. So, I was keen to get the ball rolling

# Description

Making a start towards dataframe-agnosticism. For now, this only makes `ColumnDropped` dataframe-agnostic. It requires adding an extremely lightweight dependecy (Narwhals), but the result is that computation can happen natively for pandas/Polars/modin/cuDF (and any other library which may want to become Narwhals-compliant), without any data conversion.

pandas is still a required dependency, as it's required for the rest of scikit-lego. But, it doesn't seem that far-fetched to be able to make all of scikit-lego dataframe-agnostic. If you're open to this, we could do it in stages?

There is no impact on current users, other than that Narwhals would be a required dependency (though it's really lightweight, and without any dependencies itself, so there's no risk for conflicts)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] My code follows the style guidelines (ruff)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (also to the readme.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added tests to check whether the new feature adheres to the sklearn convention
- [x] New and existing unit tests pass locally with my changes

Not sure about some of these items so I haven't checked them.

---

## Demo

pandas users, they can keep using `scikit-lego`, without needing Polars to be installed
```console
$ pip uninstall polars -y
Found existing installation: polars 0.20.23
Uninstalling polars-0.20.23:
  Successfully uninstalled polars-0.20.23
$ cat t.py 
import pandas as pd
from sklego.preprocessing import ColumnDropper

df = pd.DataFrame({
    "name": ["Swen", "Victor", "Alex"],
    "length": [1.82, 1.85, 1.80],
    "shoesize": [42, 44, 45]
})
print(ColumnDropper(["name"]).fit_transform(df))
$ python t.py 
   length  shoesize
0    1.82        42
1    1.85        44
2    1.80        45
```

But, Polars users can use this, without it doing any conversion to pandas. In particular, Polars LazyFrame is supported (and stays lazy, but here's I'm calling `.collect` to show you the output):
```console
$ cat t.py 
import polars as pl
from sklego.preprocessing import ColumnDropper

df = pl.LazyFrame({
    "name": ["Swen", "Victor", "Alex"],
    "length": [1.82, 1.85, 1.80],
    "shoesize": [42, 44, 45]
})
result = ColumnDropper(["name"]).fit_transform(df)
print(result.explain())
print(result.collect())
$ python t.py 
DF ["name", "length", "shoesize"]; PROJECT 2/3 COLUMNS; SELECTION: "None"
shape: (3, 2)
┌────────┬──────────┐
│ length ┆ shoesize │
│ ---    ┆ ---      │
│ f64    ┆ i64      │
╞════════╪══════════╡
│ 1.82   ┆ 42       │
│ 1.85   ┆ 44       │
│ 1.8    ┆ 45       │
└────────┴──────────┘
```