### PR TITLE
ci: rollback to pip

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,14 +15,12 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"
-    - name: Install uv
-      run: curl -LsSf https://astral.sh/uv/install.sh | sh
     - name: Install dependencies
       run: |
-        uv pip install pytest setuptools wheel --system
+        python -m pip install pytest setuptools wheel
     - name: Run Base Install
       run: |
-        uv pip install -e . --system
+        python -m pip install -e .
     - name: Run Checks
       run: |
         python tests/scripts/check_pip.py missing cvxpy
@@ -30,19 +28,19 @@ jobs:
         python tests/scripts/import_all.py
     - name: Install cvxpy
       run: |
-        uv pip install -e ".[cvxpy]" --system
+        python -m pip install -e ".[cvxpy]"
     - name: Run Checks
       run: |
         python tests/scripts/check_pip.py installed cvxpy scikit-learn
         python tests/scripts/import_all.py
     - name: Install All
       run: |
-        uv pip install -e ".[all]" --system
+        python -m pip install -e ".[all]"
     - name: Run Checks
       run: |
         python tests/scripts/check_pip.py installed cvxpy formulaic scikit-learn umap-learn
     - name: Docs can Build
       run: |
         sudo apt-get update && sudo apt-get install pandoc
-        uv pip install -e ".[docs]" --system
+        python -m pip install -e ".[docs]"
         mkdocs build

--- a/.github/workflows/schedule-dependencies.yml
+++ b/.github/workflows/schedule-dependencies.yml
@@ -17,21 +17,15 @@ jobs:
     steps:
     - name: Checkout source code
       uses: actions/checkout@v4
-    - name: Install uv (Unix)
-      if: runner.os != 'Windows'
-      run: curl -LsSf https://astral.sh/uv/install.sh | sh
-    - name: Install uv (Windows)
-      if: runner.os == 'Windows'
-      run: powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        uv pip install wheel --system
-        uv pip install ${{ matrix.pre-release-dependencies }} --system -e ".[test-dep]"
-        uv pip freeze
+        python -m pip install wheel 
+        python -m pip install ${{ matrix.pre-release-dependencies }}  -e ".[test-dep]"
+        python -m pip freeze
     - name: Test with pytest
       run: pytest -n auto --disable-warnings --cov=sklego -m "not cvxpy and not formulaic and not umap"
 
@@ -46,20 +40,14 @@ jobs:
     steps:
     - name: Checkout source code
       uses: actions/checkout@v4
-    - name: Install uv (Unix)
-      if: runner.os != 'Windows'
-      run: curl -LsSf https://astral.sh/uv/install.sh | sh
-    - name: Install uv (Windows)
-      if: runner.os == 'Windows'
-      run: powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        uv pip install wheel --system
-        uv pip install ${{ matrix.pre-release-dependencies }} -e ".[test-dep,${{ matrix.extra }}]" --system
-        uv pip freeze
+        python -m pip install wheel 
+        python -m pip install ${{ matrix.pre-release-dependencies }} -e ".[test-dep,${{ matrix.extra }}]" 
+        python -m pip freeze
     - name: Test with pytest
       run: pytest -n auto --disable-warnings --cov=sklego -m "${{ matrix.extra }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,17 +22,11 @@ jobs:
     steps:
     - name: Checkout source code
       uses: actions/checkout@v4
-    - name: Install uv (Unix)
-      if: runner.os != 'Windows'
-      run: curl -LsSf https://astral.sh/uv/install.sh | sh
-    - name: Install uv (Windows)
-      if: runner.os == 'Windows'
-      run: powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: uv pip install -e ".[test-all]" --system
+      run: python -m pip install -e ".[test-all]"
     - name: Test with pytest
       run: make test


### PR DESCRIPTION
# Description

As `uv` was causing some headaches, it's safer to rollback to good old pip until uv is more mature.

Solves [comment](https://github.com/koaning/scikit-lego/pull/655#issuecomment-2097452186) in #655 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)