### PR TITLE
patch: `ZeroInflatedRegressor` fix training indices

### DIFF
--- a/sklego/meta/zero_inflated_regressor.py
+++ b/sklego/meta/zero_inflated_regressor.py
@@ -108,7 +108,7 @@ class ZeroInflatedRegressor(BaseEstimator, RegressorMixin):
                 logging.warning("Classifier ignores sample_weight.")
                 self.classifier_.fit(X, y != 0)
 
-        non_zero_indices = np.where(self.classifier_.predict(X) == 1)[0]
+        non_zero_indices = np.where(y != 0)[0]
 
         if non_zero_indices.size > 0:
             try:


### PR DESCRIPTION
# Description

Issue reported in #664 is very reasonable. I tried to take a look at when `ZeroInflatedRegressor` was introduced in #442, but I couldn't find any related discussion on such choice.

Fix #664 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
