### PR TITLE
make FairClassifier data-agnostic

### DIFF
--- a/sklego/linear_model.py
+++ b/sklego/linear_model.py
@@ -11,7 +11,6 @@ from warnings import warn
 
 import narwhals as nw
 import numpy as np
-import pandas as pd
 from scipy.optimize import minimize
 from scipy.special._ufuncs import expit
 from sklearn.base import BaseEstimator, RegressorMixin

--- a/sklego/linear_model.py
+++ b/sklego/linear_model.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 from inspect import signature
 from warnings import warn
 
+import narwhals as nw
 import numpy as np
 import pandas as pd
 from scipy.optimize import minimize
@@ -492,7 +493,8 @@ class _FairClassifier(BaseEstimator, LinearClassifierMixin):
             raise ValueError(f"penalty should be either 'l1' or 'none', got {self.penalty}")
 
         self.sensitive_col_idx_ = self.sensitive_cols
-        if isinstance(X, pd.DataFrame):
+        X = nw.from_native(X, eager_only=True, strict=False)
+        if isinstance(X, nw.DataFrame):
             self.sensitive_col_idx_ = [i for i, name in enumerate(X.columns) if name in self.sensitive_cols]
         X, y = check_X_y(X, y, accept_large_sparse=False)
 

--- a/sklego/metrics.py
+++ b/sklego/metrics.py
@@ -78,7 +78,7 @@ def p_percent_score(sensitive_column, positive_target=1):
         """Remember: X is the thing going *in* to your pipeline."""
         sensitive_col = X[:, sensitive_column] if isinstance(X, np.ndarray) else X[sensitive_column]
 
-        if not np.all((sensitive_col == 0) | (sensitive_col == 1)):
+        if not ((sensitive_col == 0) | (sensitive_col == 1)).all():
             raise ValueError(
                 f"p_percent_score only supports binary indicator columns for `column`. "
                 f"Found values {np.unique(sensitive_col)}"

--- a/sklego/metrics.py
+++ b/sklego/metrics.py
@@ -152,7 +152,7 @@ def equal_opportunity_score(sensitive_column, positive_target=1):
         """Remember: X is the thing going *in* to your pipeline."""
         sensitive_col = X[:, sensitive_column] if isinstance(X, np.ndarray) else X[sensitive_column]
 
-        if not np.all((sensitive_col == 0) | (sensitive_col == 1)):
+        if not ((sensitive_col == 0) | (sensitive_col == 1)).all():
             raise ValueError(
                 f"equal_opportunity_score only supports binary indicator columns for `column`. "
                 f"Found values {np.unique(sensitive_col)}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,7 +141,7 @@ def sensitive_classification_dataset():
 
     return df[["x1", "x2"]], df["y"]
 
-@pytest.fixture(params=[pd.DataFrame])
+@pytest.fixture(params=[pd.DataFrame, pl.DataFrame])
 def funct(request):
     return request.param
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,9 +141,14 @@ def sensitive_classification_dataset():
 
     return df[["x1", "x2"]], df["y"]
 
+@pytest.fixture(params=[pd.DataFrame])
+def funct(request):
+    return request.param
+
+
 @pytest.fixture
-def sensitive_classification_dataset_equalopportunity():
-    df = pd.DataFrame(
+def sensitive_classification_dataset_equalopportunity(funct):
+    df = funct(
         {
             "x1": [1, 0, 1, 0, 1, 0, 1, 1],
             "x2": [0, 0, 0, 0, 0, 1, 1, 1],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import itertools as it
 
 import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
 from sklearn.utils import estimator_checks
 
@@ -130,6 +131,18 @@ def random_xy_dataset_multitarget(request):
 
 @pytest.fixture
 def sensitive_classification_dataset():
+    df = pd.DataFrame(
+        {
+            "x1": [1, 0, 1, 0, 1, 0, 1, 1],
+            "x2": [0, 0, 0, 0, 0, 1, 1, 1],
+            "y": [1, 1, 1, 0, 1, 0, 0, 0],
+        }
+    )
+
+    return df[["x1", "x2"]], df["y"]
+
+@pytest.fixture
+def sensitive_classification_dataset_equalopportunity():
     df = pd.DataFrame(
         {
             "x1": [1, 0, 1, 0, 1, 0, 1, 1],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,6 +141,7 @@ def sensitive_classification_dataset():
 
     return df[["x1", "x2"]], df["y"]
 
+
 @pytest.fixture(params=[pd.DataFrame, pl.DataFrame])
 def funct(request):
     return request.param

--- a/tests/test_estimators/test_demographic_parity.py
+++ b/tests/test_estimators/test_demographic_parity.py
@@ -89,9 +89,9 @@ def test_same_logistic_multiclass(random_xy_dataset_multiclf):
     _test_same(random_xy_dataset_multiclf)
 
 
-def test_regularization(sensitive_classification_dataset):
+def test_regularization(sensitive_classification_dataset_equalopportunity):
     """Tests whether increasing regularization decreases the norm of the coefficient vector"""
-    X, y = sensitive_classification_dataset
+    X, y = sensitive_classification_dataset_equalopportunity
 
     prev_theta_norm = np.inf
     for C in [1, 0.5, 0.2, 0.1]:
@@ -101,9 +101,9 @@ def test_regularization(sensitive_classification_dataset):
         prev_theta_norm = theta_norm
 
 
-def test_fairness(sensitive_classification_dataset):
+def test_fairness(sensitive_classification_dataset_equalopportunity):
     """tests whether fairness (measured by p percent score) increases as we decrease the covariance threshold"""
-    X, y = sensitive_classification_dataset
+    X, y = sensitive_classification_dataset_equalopportunity
     scorer = p_percent_score("x1")
 
     prev_fairness = -np.inf

--- a/tests/test_estimators/test_equal_opportunity.py
+++ b/tests/test_estimators/test_equal_opportunity.py
@@ -1,4 +1,6 @@
 import numpy as np
+import pandas as pd
+import polars as pl
 import pytest
 from sklearn.linear_model import LogisticRegression
 
@@ -116,6 +118,9 @@ def test_fairness(sensitive_classification_dataset_equalopportunity):
             penalty="none",
             train_sensitive_cols=False,
         ).fit(X, y)
+        if isinstance(X, pl.DataFrame):
+            X = pd.DataFrame(X.to_dict())
+            y = pd.Series(y.to_list())
         fairness = scorer(fair, X, y)
         assert fairness >= prev_fairness
         prev_fairness = fairness

--- a/tests/test_estimators/test_equal_opportunity.py
+++ b/tests/test_estimators/test_equal_opportunity.py
@@ -1,6 +1,4 @@
 import numpy as np
-import pandas as pd
-import polars as pl
 import pytest
 from sklearn.linear_model import LogisticRegression
 
@@ -118,9 +116,6 @@ def test_fairness(sensitive_classification_dataset_equalopportunity):
             penalty="none",
             train_sensitive_cols=False,
         ).fit(X, y)
-        if isinstance(X, pl.DataFrame):
-            X = pd.DataFrame(X.to_dict())
-            y = pd.Series(y.to_list())
         fairness = scorer(fair, X, y)
         assert fairness >= prev_fairness
         prev_fairness = fairness

--- a/tests/test_estimators/test_equal_opportunity.py
+++ b/tests/test_estimators/test_equal_opportunity.py
@@ -88,9 +88,9 @@ def test_same_logistic_multiclass(random_xy_dataset_multiclf):
     _test_same(random_xy_dataset_multiclf)
 
 
-def test_regularization(sensitive_classification_dataset):
+def test_regularization(sensitive_classification_dataset_equalopportunity):
     """Tests whether increasing regularization decreases the norm of the coefficient vector"""
-    X, y = sensitive_classification_dataset
+    X, y = sensitive_classification_dataset_equalopportunity
 
     prev_theta_norm = np.inf
     for C in [1, 0.5, 0.2, 0.1]:
@@ -102,9 +102,9 @@ def test_regularization(sensitive_classification_dataset):
         prev_theta_norm = theta_norm
 
 
-def test_fairness(sensitive_classification_dataset):
+def test_fairness(sensitive_classification_dataset_equalopportunity):
     """tests whether fairness (measured by p percent score) increases as we decrease the covariance threshold"""
-    X, y = sensitive_classification_dataset
+    X, y = sensitive_classification_dataset_equalopportunity
     scorer = equal_opportunity_score("x1")
 
     prev_fairness = -np.inf


### PR DESCRIPTION
Before working on a large PR, please check with @FBruzzesi or @koaning to confirm that they agree with the direction of the PR. This discussion should take place in a [Github issue](https://github.com/koaning/scikit-lego/issues/new/choose) before working on the PR, unless it's a minor change like spelling in the docs. 

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Trying to make FairClassifier data-agnostic. Issue https://github.com/koaning/scikit-lego/issues/658
The issue is  `equal_opportunity_score` is used that to test it. But this is a public function, so Narwhals can't be added there yet. I did try but a lot of changes needed to be done (I think). 

That's why I added this to  `tests/test_estimators/test_equal_opportunity.py`: 
```
ln 121  if isinstance(X, pl.DataFrame):
           X = pd.DataFrame(X.to_dict())
           y = pd.Series(y.to_list())
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] My code follows the style guidelines (ruff)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (also to the readme.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added tests to check whether the new feature adheres to the sklearn convention
- [x] New and existing unit tests pass locally with my changes

If you feel your PR is ready for a review, ping @FBruzzesi or @koaning.
@MarcoGorelli 