### PR TITLE
ci: cvxpy needs numpy<2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ issue-tracker = "https://github.com/koaning/scikit-lego/issues"
 documentation = "https://koaning.github.io/scikit-lego/"
 
 [project.optional-dependencies]
-cvxpy = ["cmake", "osqp", "cvxpy>=1.1.8"]
+cvxpy = ["cmake", "osqp", "cvxpy>=1.1.8", "numpy<2.0"]
 formulaic = ["formulaic>=0.6.0"]
 umap = ["umap-learn>=0.4.6", "numpy<2.0"]
 


### PR DESCRIPTION
# Description

I thought it was solved but apparently it is not ([open issue on the topic in cvxpy](https://github.com/cvxpy/cvxpy/issues/2389))
Therefore I am pinning `numpy<2.0` for cvxpy.

