### PR TITLE
FEAT support polars lazyframe in add_lags

### DIFF
--- a/sklego/pandas_utils.py
+++ b/sklego/pandas_utils.py
@@ -272,6 +272,7 @@ def add_lags(X, cols, lags, drop_na=True):
     X = nw.from_native(X, strict=False)
     allowed_inputs = {
         nw.DataFrame: _add_lagged_dataframe_columns,
+        nw.LazyFrame: _add_lagged_dataframe_columns,
         np.ndarray: _add_lagged_numpy_columns,
     }
 

--- a/tests/test_pandas_utils/test_pandas_utils.py
+++ b/tests/test_pandas_utils/test_pandas_utils.py
@@ -38,11 +38,15 @@ def test_add_lags_wrong_inputs(data, frame_func):
         add_lags(invalid_df, ["X1"], 1)
 
 
-@pytest.mark.parametrize("frame_func", [pd.DataFrame, pl.DataFrame])
+@pytest.mark.parametrize("frame_func", [pd.DataFrame, pl.DataFrame, pl.LazyFrame])
 def test_add_lags_correct_df(data, frame_func):
     test_df = frame_func(data)
     expected = frame_func({"X1": [1, 2], "X2": ["178", "154"], "X1-1": [0, 1]})
     ans = add_lags(test_df, "X1", -1)
+    if isinstance(ans, pl.LazyFrame):
+        ans = ans.collect()
+    if isinstance(expected, pl.LazyFrame):
+        expected = expected.collect()
     assert [x for x in ans.columns] == [x for x in expected.columns]
     assert (ans.to_numpy() == expected.to_numpy()).all()
 


### PR DESCRIPTION
# Description

Everything in `add_lags` can stay lazy, there's no conversion to numpy or anything

BTW, the docs still show 0.8.2, just flagging this in case there's some step that needs doing to update the docs

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [ ] My code follows the style guidelines (ruff)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (also to the readme.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added tests to check whether the new feature adheres to the sklearn convention
- [ ] New and existing unit tests pass locally with my changes

