### PR TITLE
perf: make sure X.schema is only calculated once per dataframe in TypeSelector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ maintainers = [
 ]
 
 dependencies = [
-    "narwhals>=0.9.0",
+    "narwhals>=0.8.13",
     "pandas>=1.1.5",
     "scikit-learn>=1.0",
     "importlib-metadata >= 1.0; python_version < '3.8'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ maintainers = [
 ]
 
 dependencies = [
-    "narwhals>=0.8.13",
+    "narwhals>=0.9.0",
     "pandas>=1.1.5",
     "scikit-learn>=1.0",
     "importlib-metadata >= 1.0; python_version < '3.8'",

--- a/sklego/preprocessing/pandastransformers.py
+++ b/sklego/preprocessing/pandastransformers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import functools
 import warnings
+from typing import Any
 
 import narwhals as nw
 from narwhals.dependencies import get_pandas
@@ -11,20 +11,31 @@ from sklearn.utils.validation import check_is_fitted
 from sklego.common import as_list
 
 
-def _nw_match_dtype(selection):
+def _nw_match_dtype(dtype, selection):
     if selection == "number":
-        return nw.selectors.numeric()
+        return dtype in (
+            nw.Int64,
+            nw.Int32,
+            nw.Int16,
+            nw.Int8,
+            nw.UInt64,
+            nw.UInt32,
+            nw.UInt16,
+            nw.UInt8,
+            nw.Float64,
+            nw.Float32,
+        )
     if selection == "bool":
-        return nw.selectors.boolean()
+        return dtype == nw.Boolean
     if selection == "string":
-        return nw.selectors.string()
+        return dtype == nw.String
     if selection == "category":
-        return nw.selectors.categorical()
+        return dtype == nw.Categorical
     msg = f"Expected {{'number', 'bool', 'string', 'category'}}, got: {selection}, which is not (yet!) supported."
     raise ValueError(msg)
 
 
-def _nw_select_dtypes(df, include: str | list[str], exclude: str | list[str]):
+def _nw_select_dtypes(df, include: str | list[str], exclude: str | list[str], schema: dict[str, Any]):
     if not include and not exclude:
         raise ValueError("Must provide at least one of `include` or `exclude`")
 
@@ -32,17 +43,23 @@ def _nw_select_dtypes(df, include: str | list[str], exclude: str | list[str]):
         include = [include]
     if isinstance(exclude, str):
         exclude = [exclude]
+
+    exclude = exclude or []
+
     if include:
-        include = [_nw_match_dtype(x) for x in include]
+        feature_names = [
+            name
+            for name, dtype in df.schema.items()
+            if any(_nw_match_dtype(dtype, _include) for _include in include)
+            and not any(_nw_match_dtype(dtype, _exclude) for _exclude in exclude)
+        ]
     else:
-        include = [nw.selectors.all()]
-    if exclude:
-        exclude = [_nw_match_dtype(x) for x in exclude]
-    else:
-        exclude = []
-    if exclude:
-        return df.select(functools.reduce(lambda x, y: x | y, include) - functools.reduce(lambda x, y: x | y, exclude))
-    return df.select(functools.reduce(lambda x, y: x | y, include))
+        feature_names = [
+            name
+            for name, dtype in df.schema.items()
+            if not any(_nw_match_dtype(dtype, _exclude) for _exclude in exclude)
+        ]
+    return feature_names
 
 
 class ColumnDropper(BaseEstimator, TransformerMixin):
@@ -320,7 +337,9 @@ class TypeSelector(BaseEstimator, TransformerMixin):
         else:
             X = nw.from_native(X)
             self.X_dtypes_ = X.schema
-            self.feature_names_ = _nw_select_dtypes(X, include=self.include, exclude=self.exclude).columns
+            self.feature_names_ = _nw_select_dtypes(
+                X, include=self.include, exclude=self.exclude, schema=self.X_dtypes_
+            )
 
         if len(self.feature_names_) == 0:
             raise ValueError("Provided type(s) results in empty dataframe")
@@ -367,14 +386,17 @@ class TypeSelector(BaseEstimator, TransformerMixin):
             transformed_df = X.select_dtypes(include=self.include, exclude=self.exclude)
         else:
             X = nw.from_native(X)
-            if self.X_dtypes_ != X.schema:
+            X_schema = X.schema
+            if self.X_dtypes_ != X_schema:
                 raise ValueError(
                     f"Column dtypes were not equal during fit and transform. Fit types: \n"
                     f"{self.X_dtypes_}\n"
                     f"transform: \n"
                     f"{X.schema}"
                 )
-            transformed_df = _nw_select_dtypes(X, include=self.include, exclude=self.exclude)
+            transformed_df = X.select(
+                _nw_select_dtypes(X, include=self.include, exclude=self.exclude, schema=X_schema)
+            ).pipe(nw.to_native)
 
         return transformed_df
 

--- a/sklego/preprocessing/pandastransformers.py
+++ b/sklego/preprocessing/pandastransformers.py
@@ -35,7 +35,7 @@ def _nw_match_dtype(dtype, selection):
     raise ValueError(msg)
 
 
-def _nw_select_dtypes(df, include: str | list[str], exclude: str | list[str], schema: dict[str, Any]):
+def _nw_select_dtypes(include: str | list[str], exclude: str | list[str], schema: dict[str, Any]):
     if not include and not exclude:
         raise ValueError("Must provide at least one of `include` or `exclude`")
 
@@ -49,15 +49,13 @@ def _nw_select_dtypes(df, include: str | list[str], exclude: str | list[str], sc
     if include:
         feature_names = [
             name
-            for name, dtype in df.schema.items()
+            for name, dtype in schema.items()
             if any(_nw_match_dtype(dtype, _include) for _include in include)
             and not any(_nw_match_dtype(dtype, _exclude) for _exclude in exclude)
         ]
     else:
         feature_names = [
-            name
-            for name, dtype in df.schema.items()
-            if not any(_nw_match_dtype(dtype, _exclude) for _exclude in exclude)
+            name for name, dtype in schema.items() if not any(_nw_match_dtype(dtype, _exclude) for _exclude in exclude)
         ]
     return feature_names
 
@@ -337,9 +335,7 @@ class TypeSelector(BaseEstimator, TransformerMixin):
         else:
             X = nw.from_native(X)
             self.X_dtypes_ = X.schema
-            self.feature_names_ = _nw_select_dtypes(
-                X, include=self.include, exclude=self.exclude, schema=self.X_dtypes_
-            )
+            self.feature_names_ = _nw_select_dtypes(include=self.include, exclude=self.exclude, schema=self.X_dtypes_)
 
         if len(self.feature_names_) == 0:
             raise ValueError("Provided type(s) results in empty dataframe")
@@ -395,7 +391,7 @@ class TypeSelector(BaseEstimator, TransformerMixin):
                     f"{X.schema}"
                 )
             transformed_df = X.select(
-                _nw_select_dtypes(X, include=self.include, exclude=self.exclude, schema=X_schema)
+                _nw_select_dtypes(include=self.include, exclude=self.exclude, schema=X_schema)
             ).pipe(nw.to_native)
 
         return transformed_df

--- a/tests/test_preprocessing/test_pandastypeselector.py
+++ b/tests/test_preprocessing/test_pandastypeselector.py
@@ -69,6 +69,22 @@ def test_get_feature_names(frame_func):
 
 
 @pytest.mark.parametrize("frame_func", [pd.DataFrame, pl.DataFrame])
+@pytest.mark.parametrize(
+    ("include", "exclude", "expected"),
+    [
+        ("number", None, ["a", "c"]),
+        ("bool", None, ["b"]),
+        (None, "number", ["b", "d"]),
+        (None, ["number", "bool"], ["d"]),
+    ],
+)
+def test_include_vs_exclude(frame_func, include, exclude, expected):
+    df = frame_func({"a": [4, 5, 6], "b": [True, False, True], "c": [4.0, 5.0, 6.0], "d": ["a", "b", "c"]})
+    transformer_number = TypeSelector(include=include, exclude=exclude).fit(df)
+    assert transformer_number.get_feature_names() == expected
+
+
+@pytest.mark.parametrize("frame_func", [pd.DataFrame, pl.DataFrame])
 def test_get_feature_names_deprecated(frame_func):
     df = frame_func({"a": [4, 5, 6], "b": ["4", "5", "6"]})
     with pytest.deprecated_call(match="Please use `from sklego.preprocessing import TypeSelector`"):

--- a/tests/test_preprocessing/test_pandastypeselector.py
+++ b/tests/test_preprocessing/test_pandastypeselector.py
@@ -80,8 +80,10 @@ def test_get_feature_names(frame_func):
 )
 def test_include_vs_exclude(frame_func, include, exclude, expected):
     df = frame_func({"a": [4, 5, 6], "b": [True, False, True], "c": [4.0, 5.0, 6.0], "d": ["a", "b", "c"]})
-    transformer_number = TypeSelector(include=include, exclude=exclude).fit(df)
-    assert transformer_number.get_feature_names() == expected
+    type_selector = TypeSelector(include=include, exclude=exclude).fit(df)
+    assert type_selector.get_feature_names() == expected
+    result = type_selector.transform(df)
+    assert isinstance(result, frame_func)
 
 
 @pytest.mark.parametrize("frame_func", [pd.DataFrame, pl.DataFrame])


### PR DESCRIPTION
# Description

Refactors `TypeSelector` to use Narwhals selectors, as opposed to hard-coding types

This is preferable because, for Polars LazyFrames, getting the schema isn't a free operation (especially if the original dataframe is on the cloud - `LazyFrame.schema` may get renamed to `LazyFrame.collect_schema` for this reason)

I've also expanded the tests

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [ ] My code follows the style guidelines (ruff)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (also to the readme.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added tests to check whether the new feature adheres to the sklearn convention
- [ ] New and existing unit tests pass locally with my changes

