### PR TITLE
patch: `.drop(columns=...)` test hotfix

### DIFF
--- a/tests/test_meta/test_hierarchical_predictor.py
+++ b/tests/test_meta/test_hierarchical_predictor.py
@@ -188,10 +188,11 @@ def test_shrinkage(meta_cls, base_estimator, task, metric, shrinkage):
     """
     X, y, groups = make_hierarchical_dataset(task, frame_func=frame_funcs[randint(0, 1)])
 
+    X_ = nw.from_native(X).drop(groups).pipe(nw.to_native)
     meta_model = meta_cls(estimator=clone(base_estimator), groups=groups, **shrinkage).fit(X, y)
-    base_model = clone(base_estimator).fit(X.drop(columns=groups), y)
+    base_model = clone(base_estimator).fit(X_, y)
 
-    assert metric(y, base_model.predict(X.drop(columns=groups))) <= metric(y, meta_model.predict(X))
+    assert metric(y, base_model.predict(X_)) <= metric(y, meta_model.predict(X))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Fix a test that is [failing in CI (--pre flag)](https://github.com/koaning/scikit-lego/actions/runs/9523783648/job/26255734681) since polars does not support the `columns` keyword in `drop` method.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] My code follows the style guidelines (ruff)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (also to the readme.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added tests to check whether the new feature adheres to the sklearn convention
- [ ] New and existing unit tests pass locally with my changes
