### PR TITLE
patch: `strict=False` in polars constructor

### DIFF
--- a/tests/test_pandas_utils/test_pandas_utils.py
+++ b/tests/test_pandas_utils/test_pandas_utils.py
@@ -38,11 +38,10 @@ def test_add_lags_wrong_inputs(data, frame_func):
         add_lags(invalid_df, ["X1"], 1)
 
 
-@pytest.mark.parametrize("frame_func", [
-    pd.DataFrame,
-    lambda data: pl.DataFrame(data, strict=False),
-    lambda data: pl.LazyFrame(data, strict=False)
-])
+@pytest.mark.parametrize(
+    "frame_func",
+    [pd.DataFrame, lambda data: pl.DataFrame(data, strict=False), lambda data: pl.LazyFrame(data, strict=False)],
+)
 def test_add_lags_correct_df(data, frame_func):
     test_df = frame_func(data)
     expected = frame_func({"X1": [1, 2], "X2": ["178", "154"], "X1-1": [0, 1]})

--- a/tests/test_pandas_utils/test_pandas_utils.py
+++ b/tests/test_pandas_utils/test_pandas_utils.py
@@ -38,7 +38,11 @@ def test_add_lags_wrong_inputs(data, frame_func):
         add_lags(invalid_df, ["X1"], 1)
 
 
-@pytest.mark.parametrize("frame_func", [pd.DataFrame, pl.DataFrame, pl.LazyFrame])
+@pytest.mark.parametrize("frame_func", [
+    pd.DataFrame,
+    lambda data: pl.DataFrame(data, strict=False),
+    lambda data: pl.LazyFrame(data, strict=False)
+])
 def test_add_lags_correct_df(data, frame_func):
     test_df = frame_func(data)
     expected = frame_func({"X1": [1, 2], "X2": ["178", "154"], "X1-1": [0, 1]})
@@ -56,7 +60,7 @@ def test_add_lags_correct_X(test_X):
     assert (add_lags(test_X, [0, 1], [1, 2]) == expected).all()
 
 
-@pytest.mark.parametrize("frame_func", [pd.DataFrame, pl.DataFrame])
+@pytest.mark.parametrize("frame_func", [pd.DataFrame, lambda data: pl.DataFrame(data, strict=False)])
 def test_add_lagged_dataframe_columns(data, frame_func):
     test_df = nw.from_native(frame_func(data))
     with pytest.raises(KeyError, match="The column does not exist"):


### PR DESCRIPTION
# Description

I wonder how this was not failing before, anyway, now all polars constructors in `test_pandas_utils` use the `strict=False` flag

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] My code follows the style guidelines (ruff)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (also to the readme.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added tests to check whether the new feature adheres to the sklearn convention
- [x] New and existing unit tests pass locally with my changes
