### PR TITLE
feat: `RepeatingBasisFunction.inverse_transform`

### DIFF
--- a/tests/test_preprocessing/test_repeatingbasisfunction.py
+++ b/tests/test_preprocessing/test_repeatingbasisfunction.py
@@ -50,3 +50,20 @@ def test_when_rbf_helper_receives_more_than_one_col_raises_value_error(df):
     rbf_helper_tf = _RepeatingBasisFunction()
     with pytest.raises(ValueError):
         rbf_helper_tf.fit(X, y)
+        
+def test_pandas_output(df):
+    X, y = df[["a", "b", "c", "d"]], df[["e"]]
+    tf = RepeatingBasisFunction(column=0, n_periods=4, remainder="passthrough")
+    tf.set_output(transform='pandas')
+    Z = tf.fit(X, y).transform(X)
+    assert isinstance(Z, pd.core.frame.DataFrame)
+
+def test_inverse_transform(df):
+    X, y = df[["a", "b", "c", "d"]], df[["e"]]
+    tf = RepeatingBasisFunction(column=0, n_periods=4, input_range=(0,7), remainder="drop")
+    Z = tf.fit(X, y).transform(X)
+    assert np.allclose(
+      X["a"], 
+      tf.pipeline_.named_transformers_['repeatingbasis'].inverse_transform(Z), 
+      rtol=1e-08, 
+      atol=1e-12)


### PR DESCRIPTION
# Description

This PR implements `get_feature_names_out()` for `_RepeatingBasisFunction`, and `RepeatingBasisFunction` (which inherits feature names from the former).

This PR also implements an inverse_transform for `_RepeatingBasisFunction` in passing. I did not include a more general implementation for `RepeatingBasisFunction` (as the one I use requires importing pandas), but the inverse_transform() can be accessed from the fitted transformer via `.pipeline_.named_transformers_['repeatingbasis'].inverse_transform()`). It's a rare use case, but it shouldn't affect other uses in any way, so I figured I'd include it. Note that the transformation is only invertible if the original values are in the input_range (upper bound excluded). Otherwise, the reconstructed values are only equal modulo the width of the range.

Two tests have been added to test_repeatingbasisfunction.py:

  - test that set_output(transform='pandas') works properly with `RepeatingBasisFunction`
  - test that the new `inverse_transform()` for `_RepeatingBasisFunction` truly recovers the original values (as long as they fall within the input_range).

Note that for feature names, ClassNamePrefixFeaturesOutMixin could also be used if `self.n_periods` was renamed to `self._n_features_out`, but I didn't see a simple way of keeping the original column name as prefix, so I adopted a solution perhaps more idiosyncratic.

It's a minor PR overall, so I didn't ping before submitting. I hope it's okay.

Progress on Issue #543

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [X] My code follows the style guidelines (ruff)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (also to the readme.md)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added tests to check whether the new feature adheres to the sklearn convention
- [X] New and existing unit tests pass locally with my changes

If you feel your PR is ready for a review, ping @FBruzzesi or @koaning.
