### PR TITLE
docs: `LowessRegression` usage docstring

### DIFF
--- a/sklego/linear_model.py
+++ b/sklego/linear_model.py
@@ -51,7 +51,7 @@ class LowessRegression(BaseEstimator, RegressorMixin):
         The target (training) values.
 
 
-    Example
+    Examples
     -------
     ```python
     from sklego.linear_model import LowessRegression

--- a/sklego/linear_model.py
+++ b/sklego/linear_model.py
@@ -49,6 +49,25 @@ class LowessRegression(BaseEstimator, RegressorMixin):
         The training data.
     y_ : np.ndarray of shape (n_samples,)
         The target (training) values.
+
+
+    Example
+    -------
+    ```python
+    from sklego.linear_model import LowessRegression
+    from sklearn.datasets import make_regression
+    from sklearn.model_selection import train_test_split
+
+    X, y = make_regression(n_samples=100, n_features=2, noise=10)
+
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+
+    lowess = LowessRegression(sigma=1, span=0.5)
+    lowess.fit(X_train, y_train)
+
+    y_pred = lowess.predict(X_test)
+    print(y_pred)
+    ```
     """
 
     def __init__(self, sigma=1, span=None):

--- a/tests/test_meta/test_zero_inflated_regressor.py
+++ b/tests/test_meta/test_zero_inflated_regressor.py
@@ -112,8 +112,8 @@ def test_score_samples():
     # Where the classifier prediction is zero, then the score is by something greater than 0.
     assert approx_gte(scores[~pred_is_non_zero], preds[~pred_is_non_zero])
 
-def test_no_predict_proba():
 
+def test_no_predict_proba():
     np.random.seed(0)
     X = np.random.randn(1_000, 4)
     y = ((X[:, 0] > 0) & (X[:, 1] > 0)) * np.abs(X[:, 2] * X[:, 3] ** 2)
@@ -125,4 +125,3 @@ def test_no_predict_proba():
 
     with pytest.raises(AttributeError, match="This 'ZeroInflatedRegressor' has no attribute 'score_samples'"):
         zir.score_samples(X)
-    


### PR DESCRIPTION
Hey @FBruzzesi , adding a docstring for LowessRegression. A change has been done in a test file automatically by ruff, let me know if you want me to revert it.

# Description

Fixes https://github.com/koaning/scikit-lego/issues/650

## Type of change

Docs

## Checklist:

- [x] My code follows the style guidelines (ruff)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (also to the readme.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added tests to check whether the new feature adheres to the sklearn convention
- [ ] New and existing unit tests pass locally with my changes


