### PR TITLE
Multi output support for TrainOnlyTransformerMixin

### DIFF
--- a/sklego/common.py
+++ b/sklego/common.py
@@ -81,7 +81,7 @@ class TrainOnlyTransformerMixin(TransformerMixin):
         if y is None:
             check_array(X, estimator=self)
         else:
-            check_X_y(X, y, estimator=self)
+            check_X_y(X, y, estimator=self, multi_output=True)
         self.X_hash_ = self._hash(X)
         self.n_features_in_ = X.shape[1]
         return self


### PR DESCRIPTION
# Description

Solves #699 

Adds `multi_output=True` to `check_X_y` in `TrainOnlyTransformerMixin.fit`. 

This allows `TrainOnlyTransformerMixin` to work with multi-output (i.e. 2D) `y` input.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines (ruff)
- [x] New and existing unit tests pass locally with my changes
- [x] All Github Actions pipelines are passing. 
