### PR TITLE
patch: scikit-learn 1.6 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "narwhals>=1.5.0",
     "pandas>=1.1.5",
     "scikit-learn>=1.0",
-    "sklearn-compat>=0.1.1",
     "importlib-metadata >= 1.0; python_version < '3.8'",
     "importlib-resources; python_version < '3.9'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "narwhals>=1.5.0",
     "pandas>=1.1.5",
     "scikit-learn>=1.0",
+    "sklearn-compat>=0.1.1",
     "importlib-metadata >= 1.0; python_version < '3.8'",
     "importlib-resources; python_version < '3.9'",
 ]

--- a/sklego/_sklearn_compat.py
+++ b/sklego/_sklearn_compat.py
@@ -1,0 +1,520 @@
+"""Ease developer experience to support multiple versions of scikit-learn.
+
+This file is intended to be vendored in your project if you do not want to depend on
+`sklearn-compat` as a package. Then, you can import directly from this file.
+
+Be aware that depending on `sklearn-compat` does not add any additional dependencies:
+we are only depending on `scikit-learn`.
+
+Version: 0.1.1
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+from dataclasses import dataclass, field
+from typing import Callable, Literal
+
+import sklearn
+from sklearn.utils.fixes import parse_version
+
+sklearn_version = parse_version(parse_version(sklearn.__version__).base_version)
+
+
+########################################################################################
+# The following code does not depend on the sklearn version
+########################################################################################
+
+
+# tags infrastructure
+def _dataclass_args():
+    if sys.version_info < (3, 10):
+        return {}
+    return {"slots": True}
+
+
+def get_tags(estimator):
+    """Get estimator tags in a consistent format across different sklearn versions.
+
+    This function provides compatibility between sklearn versions before and after 1.6.
+    It returns either a Tags object (sklearn >= 1.6) or a converted Tags object from
+    the dictionary format (sklearn < 1.6) containing metadata about the estimator's
+    requirements and capabilities.
+
+    Parameters
+    ----------
+    estimator : estimator object
+        A scikit-learn estimator instance.
+
+    Returns
+    -------
+    tags : Tags
+        An object containing metadata about the estimator's requirements and
+        capabilities (e.g., input types, fitting requirements, classifier/regressor
+        specific tags).
+    """
+    try:
+        from sklearn.utils._tags import get_tags
+
+        return get_tags(estimator)
+    except ImportError:
+        from sklearn.utils._tags import _safe_tags
+
+        return _to_new_tags(_safe_tags(estimator), estimator)
+
+
+def _to_new_tags(old_tags, estimator=None):
+    """Utility function convert old tags (dictionary) to new tags (dataclass)."""
+    input_tags = InputTags(
+        one_d_array="1darray" in old_tags["X_types"],
+        two_d_array="2darray" in old_tags["X_types"],
+        three_d_array="3darray" in old_tags["X_types"],
+        sparse="sparse" in old_tags["X_types"],
+        categorical="categorical" in old_tags["X_types"],
+        string="string" in old_tags["X_types"],
+        dict="dict" in old_tags["X_types"],
+        positive_only=old_tags["requires_positive_X"],
+        allow_nan=old_tags["allow_nan"],
+        pairwise=old_tags["pairwise"],
+    )
+    target_tags = TargetTags(
+        required=old_tags["requires_y"],
+        one_d_labels="1dlabels" in old_tags["X_types"],
+        two_d_labels="2dlabels" in old_tags["X_types"],
+        positive_only=old_tags["requires_positive_y"],
+        multi_output=old_tags["multioutput"] or old_tags["multioutput_only"],
+        single_output=not old_tags["multioutput_only"],
+    )
+    if estimator is not None and (hasattr(estimator, "transform") or hasattr(estimator, "fit_transform")):
+        transformer_tags = TransformerTags(
+            preserves_dtype=old_tags["preserves_dtype"],
+        )
+    else:
+        transformer_tags = None
+    estimator_type = getattr(estimator, "_estimator_type", None)
+    if estimator_type == "classifier":
+        classifier_tags = ClassifierTags(
+            poor_score=old_tags["poor_score"],
+            multi_class=not old_tags["binary_only"],
+            multi_label=old_tags["multilabel"],
+        )
+    else:
+        classifier_tags = None
+    if estimator_type == "regressor":
+        regressor_tags = RegressorTags(
+            poor_score=old_tags["poor_score"],
+            multi_label=old_tags["multilabel"],
+        )
+    else:
+        regressor_tags = None
+    return Tags(
+        estimator_type=estimator_type,
+        target_tags=target_tags,
+        transformer_tags=transformer_tags,
+        classifier_tags=classifier_tags,
+        regressor_tags=regressor_tags,
+        input_tags=input_tags,
+        # Array-API was introduced in 1.3, we need to default to False if not inside
+        # the old-tags.
+        array_api_support=old_tags.get("array_api_support", False),
+        no_validation=old_tags["no_validation"],
+        non_deterministic=old_tags["non_deterministic"],
+        requires_fit=old_tags["requires_fit"],
+        _skip_test=old_tags["_skip_test"],
+    )
+
+
+if sklearn_version < parse_version("1.6"):
+    # test_common
+    from sklearn.utils.estimator_checks import _construct_instance
+
+    def type_of_target(y, input_name="", *, raise_unknown=False):
+        # fix for raise_unknown which is introduced in scikit-learn 1.6
+        from sklearn.utils.multiclass import type_of_target
+
+        def _raise_or_return(target_type):
+            """Depending on the value of raise_unknown, either raise an error or
+            return 'unknown'.
+            """
+            if raise_unknown and target_type == "unknown":
+                input = input_name if input_name else "data"
+                raise ValueError(f"Unknown label type for {input}: {y!r}")
+            else:
+                return target_type
+
+        target_type = type_of_target(y, input_name=input_name)
+        return _raise_or_return(target_type)
+
+    def _construct_instances(Estimator):
+        yield _construct_instance(Estimator)
+
+    # validation
+    def validate_data(_estimator, /, **kwargs):
+        if "ensure_all_finite" in kwargs:
+            force_all_finite = kwargs.pop("ensure_all_finite")
+        else:
+            force_all_finite = True
+        return _estimator._validate_data(**kwargs, force_all_finite=force_all_finite)
+
+    def _check_n_features(estimator, X, *, reset):
+        return estimator._check_n_features(X, reset=reset)
+
+    def _check_feature_names(estimator, X, *, reset):
+        return estimator._check_feature_names(X, reset=reset)
+
+    def check_array(
+        array,
+        accept_sparse=False,
+        *,
+        accept_large_sparse=True,
+        dtype="numeric",
+        order=None,
+        copy=False,
+        force_writeable=False,
+        ensure_all_finite=None,
+        ensure_non_negative=False,
+        ensure_2d=True,
+        allow_nd=False,
+        ensure_min_samples=1,
+        ensure_min_features=1,
+        estimator=None,
+        input_name="",
+    ):
+        """Input validation on an array, list, sparse matrix or similar.
+
+        Check the original documentation for more details:
+        https://scikit-learn.org/stable/modules/generated/sklearn.utils.check_array.html
+        """
+        from sklearn.utils.validation import check_array as _check_array
+
+        if ensure_all_finite is not None:
+            force_all_finite = ensure_all_finite
+        else:
+            force_all_finite = True
+
+        check_array_params = inspect.signature(_check_array).parameters
+        kwargs = {}
+        if "force_writeable" in check_array_params:
+            kwargs["force_writeable"] = force_writeable
+        if "ensure_non_negative" in check_array_params:
+            kwargs["ensure_non_negative"] = ensure_non_negative
+
+        return _check_array(
+            array,
+            accept_sparse=accept_sparse,
+            accept_large_sparse=accept_large_sparse,
+            dtype=dtype,
+            order=order,
+            copy=copy,
+            force_all_finite=force_all_finite,
+            ensure_2d=ensure_2d,
+            allow_nd=allow_nd,
+            ensure_min_samples=ensure_min_samples,
+            ensure_min_features=ensure_min_features,
+            estimator=estimator,
+            input_name=input_name,
+            **kwargs,
+        )
+
+    # tags infrastructure
+    @dataclass(**_dataclass_args())
+    class InputTags:
+        """Tags for the input data.
+
+        Parameters
+        ----------
+        one_d_array : bool, default=False
+            Whether the input can be a 1D array.
+
+        two_d_array : bool, default=True
+            Whether the input can be a 2D array. Note that most common
+            tests currently run only if this flag is set to ``True``.
+
+        three_d_array : bool, default=False
+            Whether the input can be a 3D array.
+
+        sparse : bool, default=False
+            Whether the input can be a sparse matrix.
+
+        categorical : bool, default=False
+            Whether the input can be categorical.
+
+        string : bool, default=False
+            Whether the input can be an array-like of strings.
+
+        dict : bool, default=False
+            Whether the input can be a dictionary.
+
+        positive_only : bool, default=False
+            Whether the estimator requires positive X.
+
+        allow_nan : bool, default=False
+            Whether the estimator supports data with missing values encoded as `np.nan`.
+
+        pairwise : bool, default=False
+            This boolean attribute indicates whether the data (`X`),
+            :term:`fit` and similar methods consists of pairwise measures
+            over samples rather than a feature representation for each
+            sample.  It is usually `True` where an estimator has a
+            `metric` or `affinity` or `kernel` parameter with value
+            'precomputed'. Its primary purpose is to support a
+            :term:`meta-estimator` or a cross validation procedure that
+            extracts a sub-sample of data intended for a pairwise
+            estimator, where the data needs to be indexed on both axes.
+            Specifically, this tag is used by
+            `sklearn.utils.metaestimators._safe_split` to slice rows and
+            columns.
+        """
+
+        one_d_array: bool = False
+        two_d_array: bool = True
+        three_d_array: bool = False
+        sparse: bool = False
+        categorical: bool = False
+        string: bool = False
+        dict: bool = False
+        positive_only: bool = False
+        allow_nan: bool = False
+        pairwise: bool = False
+
+    @dataclass(**_dataclass_args())
+    class TargetTags:
+        """Tags for the target data.
+
+        Parameters
+        ----------
+        required : bool
+            Whether the estimator requires y to be passed to `fit`,
+            `fit_predict` or `fit_transform` methods. The tag is ``True``
+            for estimators inheriting from `~sklearn.base.RegressorMixin`
+            and `~sklearn.base.ClassifierMixin`.
+
+        one_d_labels : bool, default=False
+            Whether the input is a 1D labels (y).
+
+        two_d_labels : bool, default=False
+            Whether the input is a 2D labels (y).
+
+        positive_only : bool, default=False
+            Whether the estimator requires a positive y (only applicable
+            for regression).
+
+        multi_output : bool, default=False
+            Whether a regressor supports multi-target outputs or a classifier supports
+            multi-class multi-output.
+
+        single_output : bool, default=True
+            Whether the target can be single-output. This can be ``False`` if the
+            estimator supports only multi-output cases.
+        """
+
+        required: bool
+        one_d_labels: bool = False
+        two_d_labels: bool = False
+        positive_only: bool = False
+        multi_output: bool = False
+        single_output: bool = True
+
+    @dataclass(**_dataclass_args())
+    class TransformerTags:
+        """Tags for the transformer.
+
+        Parameters
+        ----------
+        preserves_dtype : list[str], default=["float64"]
+            Applies only on transformers. It corresponds to the data types
+            which will be preserved such that `X_trans.dtype` is the same
+            as `X.dtype` after calling `transformer.transform(X)`. If this
+            list is empty, then the transformer is not expected to
+            preserve the data type. The first value in the list is
+            considered as the default data type, corresponding to the data
+            type of the output when the input data type is not going to be
+            preserved.
+        """
+
+        preserves_dtype: list[str] = field(default_factory=lambda: ["float64"])
+
+    @dataclass(**_dataclass_args())
+    class ClassifierTags:
+        """Tags for the classifier.
+
+        Parameters
+        ----------
+        poor_score : bool, default=False
+            Whether the estimator fails to provide a "reasonable" test-set
+            score, which currently for classification is an accuracy of
+            0.83 on ``make_blobs(n_samples=300, random_state=0)``. The
+            datasets and values are based on current estimators in scikit-learn
+            and might be replaced by something more systematic.
+
+        multi_class : bool, default=True
+            Whether the classifier can handle multi-class
+            classification. Note that all classifiers support binary
+            classification. Therefore this flag indicates whether the
+            classifier is a binary-classifier-only or not.
+
+        multi_label : bool, default=False
+            Whether the classifier supports multi-label output.
+        """
+
+        poor_score: bool = False
+        multi_class: bool = True
+        multi_label: bool = False
+
+    @dataclass(**_dataclass_args())
+    class RegressorTags:
+        """Tags for the regressor.
+
+        Parameters
+        ----------
+        poor_score : bool, default=False
+            Whether the estimator fails to provide a "reasonable" test-set
+            score, which currently for regression is an R2 of 0.5 on
+            ``make_regression(n_samples=200, n_features=10,
+            n_informative=1, bias=5.0, noise=20, random_state=42)``. The
+            dataset and values are based on current estimators in scikit-learn
+            and might be replaced by something more systematic.
+
+        multi_label : bool, default=False
+            Whether the regressor supports multilabel output.
+        """
+
+        poor_score: bool = False
+        multi_label: bool = False
+
+    @dataclass(**_dataclass_args())
+    class Tags:
+        """Tags for the estimator.
+
+        See :ref:`estimator_tags` for more information.
+
+        Parameters
+        ----------
+        estimator_type : str or None
+            The type of the estimator. Can be one of:
+            - "classifier"
+            - "regressor"
+            - "transformer"
+            - "clusterer"
+            - "outlier_detector"
+            - "density_estimator"
+
+        target_tags : :class:`TargetTags`
+            The target(y) tags.
+
+        transformer_tags : :class:`TransformerTags` or None
+            The transformer tags.
+
+        classifier_tags : :class:`ClassifierTags` or None
+            The classifier tags.
+
+        regressor_tags : :class:`RegressorTags` or None
+            The regressor tags.
+
+        array_api_support : bool, default=False
+            Whether the estimator supports Array API compatible inputs.
+
+        no_validation : bool, default=False
+            Whether the estimator skips input-validation. This is only meant for
+            stateless and dummy transformers!
+
+        non_deterministic : bool, default=False
+            Whether the estimator is not deterministic given a fixed ``random_state``.
+
+        requires_fit : bool, default=True
+            Whether the estimator requires to be fitted before calling one of
+            `transform`, `predict`, `predict_proba`, or `decision_function`.
+
+        _skip_test : bool, default=False
+            Whether to skip common tests entirely. Don't use this unless
+            you have a *very good* reason.
+
+        input_tags : :class:`InputTags`
+            The input data(X) tags.
+        """
+
+        estimator_type: str | None
+        target_tags: TargetTags
+        transformer_tags: TransformerTags | None = None
+        classifier_tags: ClassifierTags | None = None
+        regressor_tags: RegressorTags | None = None
+        array_api_support: bool = False
+        no_validation: bool = False
+        non_deterministic: bool = False
+        requires_fit: bool = True
+        _skip_test: bool = False
+        input_tags: InputTags = field(default_factory=InputTags)
+
+    def _patched_more_tags(estimator, expected_failed_checks):
+        import copy
+
+        from sklearn.utils._tags import _safe_tags
+
+        original_tags = copy.deepcopy(_safe_tags(estimator))
+
+        def patched_more_tags(self):
+            original_tags.update({"_xfail_checks": expected_failed_checks})
+            return original_tags
+
+        estimator.__class__._more_tags = patched_more_tags
+        return estimator
+
+    def check_estimator(
+        estimator=None,
+        generate_only=False,
+        *,
+        legacy: bool = True,
+        expected_failed_checks: dict[str, str] | None = None,
+        on_skip: Literal["warn"] | None = "warn",
+        on_fail: Literal["raise", "warn"] | None = "raise",
+        callback: Callable | None = None,
+    ):
+        # legacy, on_skip, on_fail, and callback are not supported and ignored
+        from sklearn.utils.estimator_checks import check_estimator
+
+        return check_estimator(
+            _patched_more_tags(estimator, expected_failed_checks),
+            generate_only=generate_only,
+        )
+
+    def parametrize_with_checks(
+        estimators,
+        *,
+        legacy: bool = True,
+        expected_failed_checks: Callable | None = None,
+    ):
+        # legacy is not supported and ignored
+        from sklearn.utils.estimator_checks import parametrize_with_checks
+
+        estimators = [_patched_more_tags(estimator, expected_failed_checks(estimator)) for estimator in estimators]
+
+        return parametrize_with_checks(estimators)
+
+else:
+    # test_common
+    # tags infrastructure
+    from sklearn.utils import (
+        ClassifierTags,
+        InputTags,
+        RegressorTags,
+        Tags,
+        TargetTags,
+        TransformerTags,
+    )
+    from sklearn.utils._test_common.instance_generator import (
+        _construct_instances,  # noqa: F401
+    )
+    from sklearn.utils.estimator_checks import (
+        check_estimator,  # noqa: F401
+        parametrize_with_checks,  # noqa: F401
+    )
+    from sklearn.utils.multiclass import type_of_target  # noqa: F401
+
+    # validation
+    from sklearn.utils.validation import (
+        _check_feature_names,  # noqa: F401
+        _check_n_features,  # noqa: F401
+        check_array,  # noqa: F401
+        validate_data,  # noqa: F401
+    )

--- a/sklego/_sklearn_compat.py
+++ b/sklego/_sklearn_compat.py
@@ -217,6 +217,57 @@ if sklearn_version < parse_version("1.6"):
             **kwargs,
         )
 
+    def check_X_y(
+        X,
+        y,
+        accept_sparse=False,
+        *,
+        accept_large_sparse=True,
+        dtype="numeric",
+        order=None,
+        copy=False,
+        force_writeable=False,
+        ensure_all_finite=True,
+        ensure_2d=True,
+        allow_nd=False,
+        multi_output=False,
+        ensure_min_samples=1,
+        ensure_min_features=1,
+        y_numeric=False,
+        estimator=None,
+    ):
+        from sklearn.utils.validation import _check_estimator_name, _check_y, check_consistent_length
+
+        if y is None:
+            if estimator is None:
+                estimator_name = "estimator"
+            else:
+                estimator_name = _check_estimator_name(estimator)
+            raise ValueError(f"{estimator_name} requires y to be passed, but the target y is None")
+
+        X = check_array(
+            X,
+            accept_sparse=accept_sparse,
+            accept_large_sparse=accept_large_sparse,
+            dtype=dtype,
+            order=order,
+            copy=copy,
+            force_writeable=force_writeable,
+            ensure_all_finite=ensure_all_finite,
+            ensure_2d=ensure_2d,
+            allow_nd=allow_nd,
+            ensure_min_samples=ensure_min_samples,
+            ensure_min_features=ensure_min_features,
+            estimator=estimator,
+            input_name="X",
+        )
+
+        y = _check_y(y, multi_output=multi_output, y_numeric=y_numeric, estimator=estimator)
+
+        check_consistent_length(X, y)
+
+        return X, y
+
     # tags infrastructure
     @dataclass(**_dataclass_args())
     class InputTags:
@@ -516,5 +567,6 @@ else:
         _check_feature_names,  # noqa: F401
         _check_n_features,  # noqa: F401
         check_array,  # noqa: F401
+        check_X_y,  # noqa: F401
         validate_data,  # noqa: F401
     )

--- a/sklego/common.py
+++ b/sklego/common.py
@@ -5,9 +5,9 @@ from warnings import warn
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.utils.validation import check_is_fitted, check_X_y
+from sklearn.utils.validation import check_is_fitted
 
-from sklego._sklearn_compat import _check_n_features, check_array
+from sklego._sklearn_compat import _check_n_features, check_array, check_X_y
 
 
 class TrainOnlyTransformerMixin(TransformerMixin, BaseEstimator):

--- a/sklego/common.py
+++ b/sklego/common.py
@@ -5,7 +5,8 @@ from warnings import warn
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
+from sklearn.utils.validation import check_is_fitted
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 
 class TrainOnlyTransformerMixin(TransformerMixin, BaseEstimator):
@@ -79,9 +80,10 @@ class TrainOnlyTransformerMixin(TransformerMixin, BaseEstimator):
             The fitted transformer.
         """
         if y is None:
-            check_array(X, estimator=self)
+            validate_data(self, X=X, reset=True)
         else:
-            check_X_y(X, y, estimator=self, multi_output=True)
+            validate_data(self, X=X, y=y, multi_output=True, reset=True)
+        _check_n_features(self, X, reset=True)
         self.X_hash_ = self._hash(X)
         self.n_features_in_ = X.shape[1]
         return self
@@ -145,10 +147,8 @@ class TrainOnlyTransformerMixin(TransformerMixin, BaseEstimator):
             If the input dimension does not match the training dimension.
         """
         check_is_fitted(self, ["X_hash_", "n_features_in_"])
-        check_array(X, estimator=self)
-
-        if X.shape[1] != self.n_features_in_:
-            raise ValueError(f"Unexpected input dimension {X.shape[1]}, expected {self.n_features_in_}")
+        validate_data(self, X=X, reset=False)
+        _check_n_features(self, X, reset=False)
 
         if self._hash(X) == self.X_hash_:
             return self.transform_train(X)

--- a/sklego/common.py
+++ b/sklego/common.py
@@ -5,8 +5,9 @@ from warnings import warn
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.utils.validation import check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+from sklearn.utils.validation import check_is_fitted, check_X_y
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class TrainOnlyTransformerMixin(TransformerMixin, BaseEstimator):
@@ -80,9 +81,9 @@ class TrainOnlyTransformerMixin(TransformerMixin, BaseEstimator):
             The fitted transformer.
         """
         if y is None:
-            validate_data(self, X=X, reset=True)
+            check_array(X, estimator=self)
         else:
-            validate_data(self, X=X, y=y, multi_output=True, reset=True)
+            check_X_y(X, y, estimator=self, multi_output=True)
         _check_n_features(self, X, reset=True)
         self.X_hash_ = self._hash(X)
         self.n_features_in_ = X.shape[1]
@@ -147,7 +148,7 @@ class TrainOnlyTransformerMixin(TransformerMixin, BaseEstimator):
             If the input dimension does not match the training dimension.
         """
         check_is_fitted(self, ["X_hash_", "n_features_in_"])
-        validate_data(self, X=X, reset=False)
+        check_array(X, estimator=self)
         _check_n_features(self, X, reset=False)
 
         if self._hash(X) == self.X_hash_:

--- a/sklego/decomposition/pca_reconstruction.py
+++ b/sklego/decomposition/pca_reconstruction.py
@@ -2,7 +2,8 @@ import numpy as np
 from sklearn.base import BaseEstimator, OutlierMixin
 from sklearn.decomposition import PCA
 from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class PCAOutlierDetection(OutlierMixin, BaseEstimator):
@@ -95,7 +96,7 @@ class PCAOutlierDetection(OutlierMixin, BaseEstimator):
         ValueError
             If `threshold` is `None`.
         """
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=True)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=True)
         if not self.threshold:
             raise ValueError("The `threshold` value cannot be `None`.")
@@ -126,7 +127,7 @@ class PCAOutlierDetection(OutlierMixin, BaseEstimator):
             The calculated difference.
         """
         check_is_fitted(self, ["pca_", "offset_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
 
         reduced = self.pca_.transform(X)
@@ -161,7 +162,7 @@ class PCAOutlierDetection(OutlierMixin, BaseEstimator):
             The predicted data. 1 for inliers, -1 for outliers.
         """
         check_is_fitted(self, ["pca_", "offset_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
         result = np.ones(X.shape[0])
         result[self.difference(X) > self.threshold] = -1

--- a/sklego/decomposition/umap_reconstruction.py
+++ b/sklego/decomposition/umap_reconstruction.py
@@ -9,7 +9,8 @@ except ImportError:
 import numpy as np
 from sklearn.base import BaseEstimator, OutlierMixin
 from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class UMAPOutlierDetection(OutlierMixin, BaseEstimator):
@@ -101,10 +102,10 @@ class UMAPOutlierDetection(OutlierMixin, BaseEstimator):
             - If `n_components` is less than 2.
             - If `threshold` is `None`.
         """
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=True)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES, ensure_2d=True)
         _check_n_features(self, X, reset=True)
         if y is not None:
-            y = validate_data(self, y=y, reset=True)
+            y = check_array(y, estimator=self)
 
         if not self.threshold:
             raise ValueError("The `threshold` value cannot be `None`.")
@@ -135,7 +136,7 @@ class UMAPOutlierDetection(OutlierMixin, BaseEstimator):
             The calculated difference.
         """
         check_is_fitted(self, ["umap_", "offset_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES, ensure_2d=True)
         _check_n_features(self, X, reset=False)
 
         reduced = self.umap_.transform(X)
@@ -161,7 +162,7 @@ class UMAPOutlierDetection(OutlierMixin, BaseEstimator):
             The predicted data. 1 for inliers, -1 for outliers.
         """
         check_is_fitted(self, ["umap_", "offset_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES, ensure_2d=True)
         _check_n_features(self, X, reset=False)
         result = np.ones(X.shape[0])
         result[self.difference(X) > self.threshold] = -1

--- a/sklego/decomposition/umap_reconstruction.py
+++ b/sklego/decomposition/umap_reconstruction.py
@@ -8,7 +8,8 @@ except ImportError:
 
 import numpy as np
 from sklearn.base import BaseEstimator, OutlierMixin
-from sklearn.utils.validation import FLOAT_DTYPES, check_array, check_is_fitted
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 
 class UMAPOutlierDetection(OutlierMixin, BaseEstimator):
@@ -100,9 +101,10 @@ class UMAPOutlierDetection(OutlierMixin, BaseEstimator):
             - If `n_components` is less than 2.
             - If `threshold` is `None`.
         """
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=True)
+        _check_n_features(self, X, reset=True)
         if y is not None:
-            y = check_array(y, estimator=self, ensure_2d=False)
+            y = validate_data(self, y=y, reset=True)
 
         if not self.threshold:
             raise ValueError("The `threshold` value cannot be `None`.")
@@ -133,6 +135,9 @@ class UMAPOutlierDetection(OutlierMixin, BaseEstimator):
             The calculated difference.
         """
         check_is_fitted(self, ["umap_", "offset_"])
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        _check_n_features(self, X, reset=False)
+
         reduced = self.umap_.transform(X)
         diff = np.sum(np.abs(self.umap_.inverse_transform(reduced) - X), axis=1)
         if self.variant == "relative":
@@ -155,8 +160,9 @@ class UMAPOutlierDetection(OutlierMixin, BaseEstimator):
         array-like of shape (n_samples,)
             The predicted data. 1 for inliers, -1 for outliers.
         """
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         check_is_fitted(self, ["umap_", "offset_"])
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        _check_n_features(self, X, reset=False)
         result = np.ones(X.shape[0])
         result[self.difference(X) > self.threshold] = -1
         return result.astype(int)
@@ -172,3 +178,8 @@ class UMAPOutlierDetection(OutlierMixin, BaseEstimator):
 
     def _more_tags(self):
         return {"non_deterministic": True}
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.non_deterministic = True
+        return tags

--- a/sklego/decomposition/umap_reconstruction.py
+++ b/sklego/decomposition/umap_reconstruction.py
@@ -102,10 +102,17 @@ class UMAPOutlierDetection(OutlierMixin, BaseEstimator):
             - If `n_components` is less than 2.
             - If `threshold` is `None`.
         """
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES, ensure_2d=True)
+        X = check_array(
+            X,
+            estimator=self,
+            dtype=FLOAT_DTYPES,
+            ensure_2d=True,
+            ensure_min_features=self.n_components,
+            ensure_min_samples=2,
+        )
         _check_n_features(self, X, reset=True)
         if y is not None:
-            y = check_array(y, estimator=self)
+            y = check_array(y, estimator=self, ensure_2d=False)
 
         if not self.threshold:
             raise ValueError("The `threshold` value cannot be `None`.")
@@ -119,7 +126,6 @@ class UMAPOutlierDetection(OutlierMixin, BaseEstimator):
         )
         self.umap_.fit(X, y)
         self.offset_ = -self.threshold
-        self.n_features_in_ = X.shape[1]
         return self
 
     def difference(self, X):

--- a/sklego/dummy.py
+++ b/sklego/dummy.py
@@ -2,9 +2,9 @@ from warnings import warn
 
 import numpy as np
 from sklearn.base import BaseEstimator, RegressorMixin
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_random_state, check_X_y
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_random_state
 
-from ._sklearn_compat import _check_n_features, check_array
+from ._sklearn_compat import _check_n_features, check_array, check_X_y
 
 
 class RandomRegressor(RegressorMixin, BaseEstimator):

--- a/sklego/dummy.py
+++ b/sklego/dummy.py
@@ -2,12 +2,9 @@ from warnings import warn
 
 import numpy as np
 from sklearn.base import BaseEstimator, RegressorMixin
-from sklearn.utils.validation import (
-    FLOAT_DTYPES,
-    check_is_fitted,
-    check_random_state,
-)
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_random_state, check_X_y
+
+from ._sklearn_compat import _check_n_features, check_array
 
 
 class RandomRegressor(RegressorMixin, BaseEstimator):
@@ -71,7 +68,7 @@ class RandomRegressor(RegressorMixin, BaseEstimator):
         """
         if self.strategy not in self._ALLOWED_STRATEGIES:
             raise ValueError(f"strategy {self.strategy} is not in {self._ALLOWED_STRATEGIES}")
-        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
+        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=True)
 
         self.min_ = np.min(y)
@@ -98,7 +95,7 @@ class RandomRegressor(RegressorMixin, BaseEstimator):
         rs = check_random_state(self.random_state)
         check_is_fitted(self, ["n_features_in_", "min_", "max_", "mu_", "sigma_"])
 
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
 
         if self.strategy == "normal":

--- a/sklego/feature_selection/mrmr.py
+++ b/sklego/feature_selection/mrmr.py
@@ -4,9 +4,9 @@ import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.feature_selection import f_classif, f_regression
 from sklearn.feature_selection._base import SelectorMixin
-from sklearn.utils.validation import check_is_fitted, check_X_y
+from sklearn.utils.validation import check_is_fitted
 
-from sklego._sklearn_compat import _check_n_features
+from sklego._sklearn_compat import _check_n_features, check_X_y
 
 
 def _redundancy_pearson(X, selected, left):

--- a/sklego/feature_selection/mrmr.py
+++ b/sklego/feature_selection/mrmr.py
@@ -4,7 +4,8 @@ import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.feature_selection import f_classif, f_regression
 from sklearn.feature_selection._base import SelectorMixin
-from sklearn.utils.validation import check_is_fitted, check_X_y
+from sklearn.utils.validation import check_is_fitted
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 
 def _redundancy_pearson(X, selected, left):
@@ -201,13 +202,13 @@ class MaximumRelevanceMinimumRedundancy(SelectorMixin, BaseEstimator):
 
                 k parameter is not integer type or is < n_features_in (X.shape[1]) or < 1
         """
-        X, y = check_X_y(X, y, dtype="numeric", y_numeric=True)
+        X, y = validate_data(self, X=X, y=y, dtype="numeric", y_numeric=True, reset=True)
+        _check_n_features(self, X, reset=True)
         self._y_dtype = y.dtype
 
         relevance = self._get_relevance
         redundancy = self._get_redundancy
 
-        self.n_features_in_ = X.shape[1]
         left_features = list(range(self.n_features_in_))
         selected_features = []
         selected_scores = []

--- a/sklego/feature_selection/mrmr.py
+++ b/sklego/feature_selection/mrmr.py
@@ -4,8 +4,9 @@ import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.feature_selection import f_classif, f_regression
 from sklearn.feature_selection._base import SelectorMixin
-from sklearn.utils.validation import check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+from sklearn.utils.validation import check_is_fitted, check_X_y
+
+from sklego._sklearn_compat import _check_n_features
 
 
 def _redundancy_pearson(X, selected, left):
@@ -202,7 +203,7 @@ class MaximumRelevanceMinimumRedundancy(SelectorMixin, BaseEstimator):
 
                 k parameter is not integer type or is < n_features_in (X.shape[1]) or < 1
         """
-        X, y = validate_data(self, X=X, y=y, dtype="numeric", y_numeric=True, reset=True)
+        X, y = check_X_y(X, y, estimator=self, dtype="numeric", y_numeric=True)
         _check_n_features(self, X, reset=True)
         self._y_dtype = y.dtype
 

--- a/sklego/linear_model.py
+++ b/sklego/linear_model.py
@@ -17,9 +17,9 @@ from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.linear_model._base import LinearClassifierMixin
 from sklearn.multiclass import OneVsOneClassifier, OneVsRestClassifier
 from sklearn.preprocessing import LabelEncoder
-from sklearn.utils.validation import FLOAT_DTYPES, _check_sample_weight, check_is_fitted, check_X_y, column_or_1d
+from sklearn.utils.validation import FLOAT_DTYPES, _check_sample_weight, check_is_fitted, column_or_1d
 
-from sklego._sklearn_compat import _check_n_features, check_array
+from sklego._sklearn_compat import _check_n_features, check_array, check_X_y
 
 
 class LowessRegression(RegressorMixin, BaseEstimator):

--- a/sklego/linear_model.py
+++ b/sklego/linear_model.py
@@ -25,6 +25,7 @@ from sklearn.utils.validation import (
     check_is_fitted,
     column_or_1d,
 )
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 
 class LowessRegression(RegressorMixin, BaseEstimator):
@@ -96,7 +97,8 @@ class LowessRegression(RegressorMixin, BaseEstimator):
             - If `span` is not between 0 and 1.
             - If `sigma` is negative.
         """
-        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
+        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
+        _check_n_features(self, X, reset=True)
         if self.span is not None:
             if not 0 <= self.span <= 1:
                 raise ValueError(f"Param `span` must be 0 <= span <= 1, got: {self.span}")
@@ -138,8 +140,9 @@ class LowessRegression(RegressorMixin, BaseEstimator):
         array-like of shape (n_samples,)
             The predicted values.
         """
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         check_is_fitted(self, ["X_", "y_"])
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        _check_n_features(self, X, reset=False)
 
         try:
             results = np.stack([np.average(self.y_, weights=self._calc_wts(x_i=x_i)) for x_i in X])
@@ -233,7 +236,8 @@ class ProbWeightRegression(RegressorMixin, BaseEstimator):
         self : ProbWeightRegression
             The fitted estimator.
         """
-        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
+        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
+        _check_n_features(self, X, reset=True)
 
         # Construct the problem.
         betas = cp.Variable(X.shape[1])
@@ -263,8 +267,10 @@ class ProbWeightRegression(RegressorMixin, BaseEstimator):
         array-like of shape (n_samples,)
             The predicted data.
         """
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         check_is_fitted(self, ["coef_"])
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        _check_n_features(self, X, reset=False)
+
         return np.dot(X, self.coef_)
 
     @property
@@ -381,7 +387,9 @@ class DeadZoneRegressor(RegressorMixin, BaseEstimator):
         ValueError
             If `effect` is not one of "linear", "quadratic" or "constant".
         """
-        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
+        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
+        _check_n_features(self, X, reset=True)
+
         if self.effect not in self._ALLOWED_EFFECTS:
             raise ValueError(f"effect {self.effect} must be in {self._ALLOWED_EFFECTS}")
 
@@ -458,8 +466,10 @@ class DeadZoneRegressor(RegressorMixin, BaseEstimator):
         array-like of shape (n_samples,)
             The predicted data.
         """
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         check_is_fitted(self, ["coef_"])
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        _check_n_features(self, X, reset=False)
+
         return np.dot(X, self.coef_)
 
     @property
@@ -1053,7 +1063,9 @@ class BaseScipyMinimizeRegressor(RegressorMixin, BaseEstimator, ABC):
         This method is called by `fit` to prepare the inputs for the optimization problem. It adds an intercept column
         to `X` if `fit_intercept=True`, and returns the loss function and its gradient.
         """
-        X, y = check_X_y(X, y, y_numeric=True)
+        X, y = validate_data(self, X=X, y=y, y_numeric=True, reset=True)
+        _check_n_features(self, X, reset=True)
+
         sample_weight = _check_sample_weight(sample_weight, X)
         self.n_features_in_ = X.shape[1]
 
@@ -1083,7 +1095,8 @@ class BaseScipyMinimizeRegressor(RegressorMixin, BaseEstimator, ABC):
             The predicted data.
         """
         check_is_fitted(self)
-        X = check_array(X)
+        X = validate_data(self, X=X, reset=False)
+        _check_n_features(self, X, reset=False)
 
         return X @ self.coef_ + self.intercept_
 

--- a/sklego/linear_model.py
+++ b/sklego/linear_model.py
@@ -17,15 +17,9 @@ from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.linear_model._base import LinearClassifierMixin
 from sklearn.multiclass import OneVsOneClassifier, OneVsRestClassifier
 from sklearn.preprocessing import LabelEncoder
-from sklearn.utils import check_X_y
-from sklearn.utils.validation import (
-    FLOAT_DTYPES,
-    _check_sample_weight,
-    check_array,
-    check_is_fitted,
-    column_or_1d,
-)
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+from sklearn.utils.validation import FLOAT_DTYPES, _check_sample_weight, check_is_fitted, check_X_y, column_or_1d
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class LowessRegression(RegressorMixin, BaseEstimator):
@@ -97,7 +91,7 @@ class LowessRegression(RegressorMixin, BaseEstimator):
             - If `span` is not between 0 and 1.
             - If `sigma` is negative.
         """
-        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
+        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=True)
         if self.span is not None:
             if not 0 <= self.span <= 1:
@@ -141,7 +135,7 @@ class LowessRegression(RegressorMixin, BaseEstimator):
             The predicted values.
         """
         check_is_fitted(self, ["X_", "y_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
 
         try:
@@ -236,7 +230,7 @@ class ProbWeightRegression(RegressorMixin, BaseEstimator):
         self : ProbWeightRegression
             The fitted estimator.
         """
-        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
+        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=True)
 
         # Construct the problem.
@@ -268,7 +262,7 @@ class ProbWeightRegression(RegressorMixin, BaseEstimator):
             The predicted data.
         """
         check_is_fitted(self, ["coef_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
 
         return np.dot(X, self.coef_)
@@ -387,7 +381,7 @@ class DeadZoneRegressor(RegressorMixin, BaseEstimator):
         ValueError
             If `effect` is not one of "linear", "quadratic" or "constant".
         """
-        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
+        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=True)
 
         if self.effect not in self._ALLOWED_EFFECTS:
@@ -467,7 +461,7 @@ class DeadZoneRegressor(RegressorMixin, BaseEstimator):
             The predicted data.
         """
         check_is_fitted(self, ["coef_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
 
         return np.dot(X, self.coef_)
@@ -1063,7 +1057,7 @@ class BaseScipyMinimizeRegressor(RegressorMixin, BaseEstimator, ABC):
         This method is called by `fit` to prepare the inputs for the optimization problem. It adds an intercept column
         to `X` if `fit_intercept=True`, and returns the loss function and its gradient.
         """
-        X, y = validate_data(self, X=X, y=y, y_numeric=True, reset=True)
+        X, y = check_X_y(X, y, estimator=self, y_numeric=True)
         _check_n_features(self, X, reset=True)
 
         sample_weight = _check_sample_weight(sample_weight, X)
@@ -1095,7 +1089,7 @@ class BaseScipyMinimizeRegressor(RegressorMixin, BaseEstimator, ABC):
             The predicted data.
         """
         check_is_fitted(self)
-        X = validate_data(self, X=X, reset=False)
+        X = check_array(X, estimator=self)
         _check_n_features(self, X, reset=False)
 
         return X @ self.coef_ + self.intercept_

--- a/sklego/linear_model.py
+++ b/sklego/linear_model.py
@@ -970,8 +970,6 @@ class BaseScipyMinimizeRegressor(RegressorMixin, BaseEstimator, ABC):
         self.fit_intercept = fit_intercept
         self.copy_X = copy_X
         self.positive = positive
-        if method not in ("SLSQP", "TNC", "L-BFGS-B"):
-            raise ValueError(f'method should be one of "SLSQP", "TNC", "L-BFGS-B", ' f"got {method} instead")
         self.method = method
 
     @abstractmethod
@@ -1021,6 +1019,10 @@ class BaseScipyMinimizeRegressor(RegressorMixin, BaseEstimator, ABC):
         self : BaseScipyMinimizeRegressor
             Fitted linear model.
         """
+        if self.method not in {"SLSQP", "TNC", "L-BFGS-B"}:
+            msg = f"method should be one of 'SLSQP', 'TNC', 'L-BFGS-B', got {self.method} instead"
+            raise ValueError(msg)
+
         X_, grad_loss, loss = self._prepare_inputs(X, sample_weight, y)
 
         d = X_.shape[1] - self.n_features_in_  # This is either zero or one.

--- a/sklego/meta/confusion_balancer.py
+++ b/sklego/meta/confusion_balancer.py
@@ -2,9 +2,9 @@ from sklearn import clone
 from sklearn.base import BaseEstimator, ClassifierMixin, MetaEstimatorMixin
 from sklearn.metrics import confusion_matrix
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
 
-from sklego._sklearn_compat import _check_n_features, check_array
+from sklego._sklearn_compat import _check_n_features, check_array, check_X_y
 from sklego.base import ProbabilisticClassifier
 
 

--- a/sklego/meta/confusion_balancer.py
+++ b/sklego/meta/confusion_balancer.py
@@ -2,9 +2,9 @@ from sklearn import clone
 from sklearn.base import BaseEstimator, ClassifierMixin, MetaEstimatorMixin
 from sklearn.metrics import confusion_matrix
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
 
+from sklego._sklearn_compat import _check_n_features, check_array
 from sklego.base import ProbabilisticClassifier
 
 
@@ -64,7 +64,7 @@ class ConfusionBalancer(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
             If the underlying estimator does not have a `predict_proba` method.
         """
 
-        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
+        X, y = check_X_y(X, y, estimator=self.estimator, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=True)
 
         if not isinstance(self.estimator, ProbabilisticClassifier):
@@ -92,7 +92,7 @@ class ConfusionBalancer(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
             The predicted values.
         """
         check_is_fitted(self, ["cfm_", "classes_", "estimator_"])
-        X = validate_data(self, X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self.estimator_, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
         preds = self.estimator_.predict_proba(X)
         return (1 - self.alpha) * preds + self.alpha * preds @ self.cfm_
@@ -111,6 +111,6 @@ class ConfusionBalancer(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
             The predicted values.
         """
         check_is_fitted(self, ["cfm_", "classes_", "estimator_"])
-        X = validate_data(self, X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self.estimator_, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
         return self.classes_[self.predict_proba(X).argmax(axis=1)]

--- a/sklego/meta/decay_estimator.py
+++ b/sklego/meta/decay_estimator.py
@@ -97,6 +97,10 @@ class DecayEstimator(BaseEstimator, MetaEstimatorMixin):
         """Checks if the wrapped estimator is a classifier."""
         return any(["ClassifierMixin" in p.__name__ for p in type(self.model).__bases__])
 
+    def _is_regressor(self):
+        """Checks if the wrapped estimator is a regressor."""
+        return any(["RegressorMixin" in p.__name__ for p in type(self.model).__bases__])
+
     @property
     def _estimator_type(self):
         """Computes `_estimator_type` dynamically from the wrapped model."""

--- a/sklego/meta/decay_estimator.py
+++ b/sklego/meta/decay_estimator.py
@@ -1,8 +1,8 @@
 from sklearn import clone
 from sklearn.base import BaseEstimator, MetaEstimatorMixin
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
 
-from sklego._sklearn_compat import _check_n_features
+from sklego._sklearn_compat import _check_n_features, check_X_y
 from sklego.meta._decay_utils import exponential_decay, linear_decay, sigmoid_decay, stepwise_decay
 
 

--- a/sklego/meta/decay_estimator.py
+++ b/sklego/meta/decay_estimator.py
@@ -1,8 +1,8 @@
 from sklearn import clone
 from sklearn.base import BaseEstimator, MetaEstimatorMixin
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
 
+from sklego._sklearn_compat import _check_n_features
 from sklego.meta._decay_utils import exponential_decay, linear_decay, sigmoid_decay, stepwise_decay
 
 
@@ -124,7 +124,7 @@ class DecayEstimator(MetaEstimatorMixin, BaseEstimator):
         """
 
         if self.check_input:
-            X, y = validate_data(self, X, y, dtype=FLOAT_DTYPES, reset=True)
+            X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=True)
 
         if self.decay_func in self._ALLOWED_DECAYS.keys():

--- a/sklego/meta/decay_estimator.py
+++ b/sklego/meta/decay_estimator.py
@@ -1,11 +1,12 @@
 from sklearn import clone
 from sklearn.base import BaseEstimator, MetaEstimatorMixin
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 from sklego.meta._decay_utils import exponential_decay, linear_decay, sigmoid_decay, stepwise_decay
 
 
-class DecayEstimator(BaseEstimator, MetaEstimatorMixin):
+class DecayEstimator(MetaEstimatorMixin, BaseEstimator):
     """Morphs an estimator such that the training weights can be adapted to ensure that points that are far away have
     less weight.
 
@@ -123,7 +124,8 @@ class DecayEstimator(BaseEstimator, MetaEstimatorMixin):
         """
 
         if self.check_input:
-            X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES, ensure_min_features=0)
+            X, y = validate_data(self, X, y, dtype=FLOAT_DTYPES, reset=True)
+        _check_n_features(self, X, reset=True)
 
         if self.decay_func in self._ALLOWED_DECAYS.keys():
             self.decay_func_ = self._ALLOWED_DECAYS[self.decay_func]
@@ -144,7 +146,6 @@ class DecayEstimator(BaseEstimator, MetaEstimatorMixin):
         if self._is_classifier():
             self.classes_ = self.estimator_.classes_
 
-        self.n_features_in_ = X.shape[1]
         return self
 
     def predict(self, X):
@@ -169,3 +170,6 @@ class DecayEstimator(BaseEstimator, MetaEstimatorMixin):
     def score(self, X, y):
         """Alias for `.score()` method of the underlying estimator."""
         return self.estimator_.score(X, y)
+
+    def __sklearn_tags__(self):
+        return self.model.__sklearn_tags__()

--- a/sklego/meta/estimator_transformer.py
+++ b/sklego/meta/estimator_transformer.py
@@ -1,8 +1,8 @@
 from sklearn import clone
 from sklearn.base import BaseEstimator, MetaEstimatorMixin, TransformerMixin
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
 
-from sklego._sklearn_compat import _check_n_features, check_array
+from sklego._sklearn_compat import _check_n_features, check_array, check_X_y
 
 
 class EstimatorTransformer(TransformerMixin, MetaEstimatorMixin, BaseEstimator):

--- a/sklego/meta/estimator_transformer.py
+++ b/sklego/meta/estimator_transformer.py
@@ -1,7 +1,8 @@
 from sklearn import clone
 from sklearn.base import BaseEstimator, MetaEstimatorMixin, TransformerMixin
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class EstimatorTransformer(TransformerMixin, MetaEstimatorMixin, BaseEstimator):
@@ -53,7 +54,7 @@ class EstimatorTransformer(TransformerMixin, MetaEstimatorMixin, BaseEstimator):
         """
 
         if self.check_input:
-            X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, multi_output=True, reset=True)
+            X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES, multi_output=True)
 
         _check_n_features(self, X, reset=True)
 
@@ -80,7 +81,7 @@ class EstimatorTransformer(TransformerMixin, MetaEstimatorMixin, BaseEstimator):
 
         check_is_fitted(self, "estimator_")
         if self.check_input:
-            X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+            X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
 
         output = getattr(self.estimator_, self.predict_func)(X)

--- a/sklego/meta/estimator_transformer.py
+++ b/sklego/meta/estimator_transformer.py
@@ -1,6 +1,7 @@
 from sklearn import clone
 from sklearn.base import BaseEstimator, MetaEstimatorMixin, TransformerMixin
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 
 class EstimatorTransformer(TransformerMixin, MetaEstimatorMixin, BaseEstimator):
@@ -52,7 +53,9 @@ class EstimatorTransformer(TransformerMixin, MetaEstimatorMixin, BaseEstimator):
         """
 
         if self.check_input:
-            X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES, multi_output=True)
+            X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, multi_output=True, reset=True)
+
+        _check_n_features(self, X, reset=True)
 
         self.multi_output_ = len(y.shape) > 1
         self.estimator_ = clone(self.estimator)
@@ -76,5 +79,9 @@ class EstimatorTransformer(TransformerMixin, MetaEstimatorMixin, BaseEstimator):
         """
 
         check_is_fitted(self, "estimator_")
+        if self.check_input:
+            X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        _check_n_features(self, X, reset=False)
+
         output = getattr(self.estimator_, self.predict_func)(X)
         return output if self.multi_output_ else output.reshape(-1, 1)

--- a/sklego/meta/grouped_predictor.py
+++ b/sklego/meta/grouped_predictor.py
@@ -401,6 +401,11 @@ class GroupedPredictor(ShrinkageMixin, MetaEstimatorMixin, BaseEstimator):
     def _more_tags(self):
         return {"allow_nan": True}
 
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.allow_nan = True
+        return tags
+
 
 class GroupedRegressor(RegressorMixin, GroupedPredictor):
     """`GroupedRegressor` is a meta-estimator that fits a separate regressor for each group in the input data.

--- a/sklego/meta/grouped_transformer.py
+++ b/sklego/meta/grouped_transformer.py
@@ -213,6 +213,11 @@ class GroupedTransformer(TransformerMixin, MetaEstimatorMixin, BaseEstimator):
     def _more_tags(self):
         return {"allow_nan": True}
 
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.allow_nan = True
+        return tags
+
     def get_feature_names_out(self) -> List[str]:
         "Alias for the `feature_names_out_` attribute defined during fit."
         return self.feature_names_out_

--- a/sklego/meta/grouped_transformer.py
+++ b/sklego/meta/grouped_transformer.py
@@ -111,6 +111,7 @@ class GroupedTransformer(TransformerMixin, MetaEstimatorMixin, BaseEstimator):
         self.groups_ = as_list(self.groups) if self.groups is not None else []
 
         X = nw.from_native(X, strict=False, eager_only=True)
+        self.n_features_in_ = X.shape[1]
 
         if isinstance(X, nw.DataFrame):
             self.feature_names_out_ = [c for c in X.columns if c not in self.groups_]
@@ -193,9 +194,12 @@ class GroupedTransformer(TransformerMixin, MetaEstimatorMixin, BaseEstimator):
         array-like of shape (n_samples, n_features)
             Data transformed per group.
         """
-        check_is_fitted(self, ["fallback_", "transformers_"])
+        check_is_fitted(self, ["n_features_in_", "transformers_"])
 
         X = nw.from_native(X, strict=False, eager_only=True)
+        if X.shape[1] != self.n_features_in_:
+            raise ValueError(f"X has {X.shape[1]} features, expected {self.n_features_in_} features.")
+
         frame = parse_X_y(X, y=None, groups=self.groups_, check_X=self.check_X, **self._check_kwargs).drop(
             "__sklego_target__"
         )

--- a/sklego/meta/ordinal_classification.py
+++ b/sklego/meta/ordinal_classification.py
@@ -3,8 +3,9 @@ from joblib import Parallel, delayed
 from sklearn import clone
 from sklearn.base import BaseEstimator, ClassifierMixin, MetaEstimatorMixin, MultiOutputMixin, is_classifier
 from sklearn.calibration import CalibratedClassifierCV
-from sklearn.utils.validation import check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+from sklearn.utils.validation import check_is_fitted, check_X_y
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class OrdinalClassifier(MultiOutputMixin, ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
@@ -130,7 +131,7 @@ class OrdinalClassifier(MultiOutputMixin, ClassifierMixin, MetaEstimatorMixin, B
         if not hasattr(self.estimator, "predict_proba"):
             raise ValueError("The estimator must implement `.predict_proba()` method.")
 
-        X, y = validate_data(self, X=X, y=y, ensure_min_samples=2, ensure_2d=True, reset=True)
+        X, y = check_X_y(X, y, estimator=self, ensure_min_samples=2, ensure_2d=True)
         _check_n_features(self, X, reset=True)
 
         self.classes_ = np.sort(np.unique(y))
@@ -173,7 +174,7 @@ class OrdinalClassifier(MultiOutputMixin, ClassifierMixin, MetaEstimatorMixin, B
             If `X` has a different number of features than the one seen during `fit`.
         """
         check_is_fitted(self, ["estimators_", "classes_"])
-        X = validate_data(self, X=X, ensure_2d=True, reset=False)
+        X = check_array(X, estimator=self, ensure_2d=True)
         _check_n_features(self, X, reset=False)
 
         raw_proba = np.array([estimator.predict_proba(X)[:, 1] for estimator in self.estimators_.values()]).T
@@ -196,7 +197,7 @@ class OrdinalClassifier(MultiOutputMixin, ClassifierMixin, MetaEstimatorMixin, B
             The predicted class labels.
         """
         check_is_fitted(self, ["estimators_", "classes_"])
-        X = validate_data(self, X=X, ensure_2d=True, reset=False)
+        X = check_array(X, estimator=self, ensure_2d=True)
         return self.classes_[np.argmax(self.predict_proba(X), axis=1)]
 
     def _fit_binary_estimator(self, X, y, y_label):

--- a/sklego/meta/ordinal_classification.py
+++ b/sklego/meta/ordinal_classification.py
@@ -3,9 +3,9 @@ from joblib import Parallel, delayed
 from sklearn import clone
 from sklearn.base import BaseEstimator, ClassifierMixin, MetaEstimatorMixin, MultiOutputMixin, is_classifier
 from sklearn.calibration import CalibratedClassifierCV
-from sklearn.utils.validation import check_is_fitted, check_X_y
+from sklearn.utils.validation import check_is_fitted
 
-from sklego._sklearn_compat import _check_n_features, check_array
+from sklego._sklearn_compat import _check_n_features, check_array, check_X_y
 
 
 class OrdinalClassifier(MultiOutputMixin, ClassifierMixin, MetaEstimatorMixin, BaseEstimator):

--- a/sklego/meta/ordinal_classification.py
+++ b/sklego/meta/ordinal_classification.py
@@ -3,7 +3,8 @@ from joblib import Parallel, delayed
 from sklearn import clone
 from sklearn.base import BaseEstimator, ClassifierMixin, MetaEstimatorMixin, MultiOutputMixin, is_classifier
 from sklearn.calibration import CalibratedClassifierCV
-from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
+from sklearn.utils.validation import check_is_fitted
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 
 class OrdinalClassifier(MultiOutputMixin, ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
@@ -129,10 +130,10 @@ class OrdinalClassifier(MultiOutputMixin, ClassifierMixin, MetaEstimatorMixin, B
         if not hasattr(self.estimator, "predict_proba"):
             raise ValueError("The estimator must implement `.predict_proba()` method.")
 
-        X, y = check_X_y(X, y, estimator=self, ensure_min_samples=2)
+        X, y = validate_data(self, X=X, y=y, ensure_min_samples=2, ensure_2d=True, reset=True)
+        _check_n_features(self, X, reset=True)
 
         self.classes_ = np.sort(np.unique(y))
-        self.n_features_in_ = X.shape[1]
 
         if self.n_classes_ < 3:
             raise ValueError("`OrdinalClassifier` can't train when less than 3 classes are present.")
@@ -172,10 +173,8 @@ class OrdinalClassifier(MultiOutputMixin, ClassifierMixin, MetaEstimatorMixin, B
             If `X` has a different number of features than the one seen during `fit`.
         """
         check_is_fitted(self, ["estimators_", "classes_"])
-        X = check_array(X, ensure_2d=True, estimator=self)
-
-        if X.shape[1] != self.n_features_in_:
-            raise ValueError(f"X has {X.shape[1]} features, expected {self.n_features_in_} features.")
+        X = validate_data(self, X=X, ensure_2d=True, reset=False)
+        _check_n_features(self, X, reset=False)
 
         raw_proba = np.array([estimator.predict_proba(X)[:, 1] for estimator in self.estimators_.values()]).T
         p_y_le = np.column_stack((np.zeros(X.shape[0]), raw_proba, np.ones(X.shape[0])))
@@ -197,6 +196,7 @@ class OrdinalClassifier(MultiOutputMixin, ClassifierMixin, MetaEstimatorMixin, B
             The predicted class labels.
         """
         check_is_fitted(self, ["estimators_", "classes_"])
+        X = validate_data(self, X=X, ensure_2d=True, reset=False)
         return self.classes_[np.argmax(self.predict_proba(X), axis=1)]
 
     def _fit_binary_estimator(self, X, y, y_label):

--- a/sklego/meta/outlier_classifier.py
+++ b/sklego/meta/outlier_classifier.py
@@ -2,7 +2,8 @@ import numpy as np
 from sklearn import clone
 from sklearn.base import BaseEstimator, ClassifierMixin, MetaEstimatorMixin
 from sklearn.calibration import _SigmoidCalibration
-from sklearn.utils.validation import check_is_fitted, check_X_y
+from sklearn.utils.validation import check_is_fitted
+from sklearn_compat.utils.validation import validate_data
 
 from sklego.base import OutlierModel
 
@@ -87,7 +88,10 @@ class OutlierClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
                 f"Passed model {self.model} does not have a `decision_function` "
                 f"method. This is required for `predict_proba` estimation."
             )
-        X, y = check_X_y(X, y)
+        if y is not None:
+            X, y = validate_data(self, X=X, y=y, reset=True)
+        else:
+            X = validate_data(self, X=X, reset=True)
         self.estimator_ = clone(self.model).fit(X, y)
         self.n_features_in_ = self.estimator_.n_features_in_
         self.classes_ = np.array([0, 1])
@@ -112,6 +116,7 @@ class OutlierClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
             The predicted values. 0 for inliers, 1 for outliers.
         """
         check_is_fitted(self, ["estimator_", "classes_"])
+        X = validate_data(self, X=X, reset=False)
         preds = self.estimator_.predict(X)
         result = (preds == -1).astype(int)
         return result
@@ -130,6 +135,7 @@ class OutlierClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
             The predicted probabilities.
         """
         check_is_fitted(self, ["estimator_", "classes_"])
+        X = validate_data(self, X=X, reset=False)
         decision_function_scores = self.estimator_.decision_function(X)
         probabilities = self._predict_proba_sigmoid.predict(decision_function_scores).reshape(-1, 1)
         complement = np.ones_like(probabilities) - probabilities

--- a/sklego/meta/outlier_classifier.py
+++ b/sklego/meta/outlier_classifier.py
@@ -2,9 +2,9 @@ import numpy as np
 from sklearn import clone
 from sklearn.base import BaseEstimator, ClassifierMixin, MetaEstimatorMixin
 from sklearn.calibration import _SigmoidCalibration
-from sklearn.utils.validation import check_is_fitted, check_X_y
+from sklearn.utils.validation import check_is_fitted
 
-from sklego._sklearn_compat import check_array
+from sklego._sklearn_compat import check_array, check_X_y
 from sklego.base import OutlierModel
 
 

--- a/sklego/meta/outlier_classifier.py
+++ b/sklego/meta/outlier_classifier.py
@@ -2,9 +2,9 @@ import numpy as np
 from sklearn import clone
 from sklearn.base import BaseEstimator, ClassifierMixin, MetaEstimatorMixin
 from sklearn.calibration import _SigmoidCalibration
-from sklearn.utils.validation import check_is_fitted
-from sklearn_compat.utils.validation import validate_data
+from sklearn.utils.validation import check_is_fitted, check_X_y
 
+from sklego._sklearn_compat import check_array
 from sklego.base import OutlierModel
 
 
@@ -89,9 +89,9 @@ class OutlierClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
                 f"method. This is required for `predict_proba` estimation."
             )
         if y is not None:
-            X, y = validate_data(self, X=X, y=y, reset=True)
+            X, y = check_X_y(estimator=self, X=X, y=y)
         else:
-            X = validate_data(self, X=X, reset=True)
+            X = check_array(X, estimator=self)
         self.estimator_ = clone(self.model).fit(X, y)
         self.n_features_in_ = self.estimator_.n_features_in_
         self.classes_ = np.array([0, 1])
@@ -116,7 +116,7 @@ class OutlierClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
             The predicted values. 0 for inliers, 1 for outliers.
         """
         check_is_fitted(self, ["estimator_", "classes_"])
-        X = validate_data(self, X=X, reset=False)
+        X = check_array(X, estimator=self)
         preds = self.estimator_.predict(X)
         result = (preds == -1).astype(int)
         return result
@@ -135,7 +135,7 @@ class OutlierClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
             The predicted probabilities.
         """
         check_is_fitted(self, ["estimator_", "classes_"])
-        X = validate_data(self, X=X, reset=False)
+        X = check_array(X, estimator=self)
         decision_function_scores = self.estimator_.decision_function(X)
         probabilities = self._predict_proba_sigmoid.predict(decision_function_scores).reshape(-1, 1)
         complement = np.ones_like(probabilities) - probabilities

--- a/sklego/meta/regression_outlier_detector.py
+++ b/sklego/meta/regression_outlier_detector.py
@@ -3,7 +3,8 @@ import numpy as np
 from sklearn import clone
 from sklearn.base import BaseEstimator, OutlierMixin
 from sklearn.utils.validation import check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class RegressionOutlierDetector(OutlierMixin, BaseEstimator):
@@ -136,7 +137,7 @@ class RegressionOutlierDetector(OutlierMixin, BaseEstimator):
         """
         X = nw.from_native(X, eager_only=True, strict=False)
         self.idx_ = np.argmax([i == self.column for i in X.columns]) if isinstance(X, nw.DataFrame) else self.column
-        X = validate_data(self, nw.to_native(X, strict=False), reset=True)
+        X = check_array(nw.to_native(X, strict=False), estimator=self)
         _check_n_features(self, X, reset=True)
 
         if not self._is_regression_model():
@@ -164,7 +165,7 @@ class RegressionOutlierDetector(OutlierMixin, BaseEstimator):
             The predicted values. 1 for inliers, -1 for outliers.
         """
         check_is_fitted(self, ["estimator_", "sd_", "idx_"])
-        X = validate_data(self, X=X, reset=False)
+        X = check_array(X, estimator=self)
         _check_n_features(self, X, reset=False)
 
         X, y = self.to_x_y(X)
@@ -192,7 +193,7 @@ class RegressionOutlierDetector(OutlierMixin, BaseEstimator):
             If `method` is not one of "sd", "relative", or "absolute".
         """
         check_is_fitted(self, ["estimator_", "sd_", "idx_"])
-        X = validate_data(self, X=X, reset=False)
+        X = check_array(X, estimator=self)
         _check_n_features(self, X, reset=False)
 
         X, y_true = self.to_x_y(X)

--- a/sklego/meta/regression_outlier_detector.py
+++ b/sklego/meta/regression_outlier_detector.py
@@ -2,7 +2,8 @@ import narwhals.stable.v1 as nw
 import numpy as np
 from sklearn import clone
 from sklearn.base import BaseEstimator, OutlierMixin
-from sklearn.utils.validation import check_array, check_is_fitted
+from sklearn.utils.validation import check_is_fitted
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 
 class RegressionOutlierDetector(OutlierMixin, BaseEstimator):
@@ -135,9 +136,8 @@ class RegressionOutlierDetector(OutlierMixin, BaseEstimator):
         """
         X = nw.from_native(X, eager_only=True, strict=False)
         self.idx_ = np.argmax([i == self.column for i in X.columns]) if isinstance(X, nw.DataFrame) else self.column
-        X = check_array(nw.to_native(X, strict=False), estimator=self)
-
-        self.n_features_in_ = X.shape[1]
+        X = validate_data(self, nw.to_native(X, strict=False), reset=True)
+        _check_n_features(self, X, reset=True)
 
         if not self._is_regression_model():
             raise ValueError("Passed model must be regression!")
@@ -164,7 +164,9 @@ class RegressionOutlierDetector(OutlierMixin, BaseEstimator):
             The predicted values. 1 for inliers, -1 for outliers.
         """
         check_is_fitted(self, ["estimator_", "sd_", "idx_"])
-        X = check_array(X, estimator=self)
+        X = validate_data(self, X=X, reset=False)
+        _check_n_features(self, X, reset=False)
+
         X, y = self.to_x_y(X)
         preds = self.estimator_.predict(X)
         return self._handle_thresholds(y, preds)
@@ -190,7 +192,9 @@ class RegressionOutlierDetector(OutlierMixin, BaseEstimator):
             If `method` is not one of "sd", "relative", or "absolute".
         """
         check_is_fitted(self, ["estimator_", "sd_", "idx_"])
-        X = check_array(X, estimator=self)
+        X = validate_data(self, X=X, reset=False)
+        _check_n_features(self, X, reset=False)
+
         X, y_true = self.to_x_y(X)
         y_pred = self.estimator_.predict(X)
         difference = y_true - y_pred

--- a/sklego/meta/subjective_classifier.py
+++ b/sklego/meta/subjective_classifier.py
@@ -3,9 +3,9 @@ from sklearn import clone
 from sklearn.base import BaseEstimator, ClassifierMixin, MetaEstimatorMixin
 from sklearn.metrics import confusion_matrix
 from sklearn.preprocessing import normalize
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
 
-from sklego._sklearn_compat import _check_n_features, check_array
+from sklego._sklearn_compat import _check_n_features, check_array, check_X_y
 
 
 class SubjectiveClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):

--- a/sklego/meta/subjective_classifier.py
+++ b/sklego/meta/subjective_classifier.py
@@ -3,8 +3,9 @@ from sklearn import clone
 from sklearn.base import BaseEstimator, ClassifierMixin, MetaEstimatorMixin
 from sklearn.metrics import confusion_matrix
 from sklearn.preprocessing import normalize
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class SubjectiveClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
@@ -110,7 +111,7 @@ class SubjectiveClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
         if self.evidence not in self._ALLOWED_EVIDENCE:
             raise ValueError(f"Invalid evidence: the provided evidence should be one of {self._ALLOWED_EVIDENCE}")
 
-        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
+        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=True)
 
         if set(y) - set(self.prior.keys()):
@@ -149,7 +150,7 @@ class SubjectiveClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
             The predicted probabilities.
         """
         check_is_fitted(self, ["posterior_matrix_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
 
         y_hats = self.estimator_.predict_proba(X)  # these are ignorant of the prior
@@ -175,7 +176,7 @@ class SubjectiveClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
             The predicted class.
         """
         check_is_fitted(self, ["posterior_matrix_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
 
         return self.classes_[self.predict_proba(X).argmax(axis=1)]

--- a/sklego/meta/subjective_classifier.py
+++ b/sklego/meta/subjective_classifier.py
@@ -3,7 +3,8 @@ from sklearn import clone
 from sklearn.base import BaseEstimator, ClassifierMixin, MetaEstimatorMixin
 from sklearn.metrics import confusion_matrix
 from sklearn.preprocessing import normalize
-from sklearn.utils.validation import FLOAT_DTYPES, check_array, check_is_fitted, check_X_y
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 
 class SubjectiveClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
@@ -109,7 +110,9 @@ class SubjectiveClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
         if self.evidence not in self._ALLOWED_EVIDENCE:
             raise ValueError(f"Invalid evidence: the provided evidence should be one of {self._ALLOWED_EVIDENCE}")
 
-        X, y = check_X_y(X, y, estimator=self.estimator, dtype=FLOAT_DTYPES)
+        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
+        _check_n_features(self, X, reset=True)
+
         if set(y) - set(self.prior.keys()):
             raise ValueError(
                 f"Training data is inconsistent with prior: no prior defined for classes "
@@ -120,7 +123,6 @@ class SubjectiveClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
         self.posterior_matrix_ = np.array(
             [[self._posterior(y, y_hat, cfm) for y_hat in range(cfm.shape[0])] for y in range(cfm.shape[0])]
         )
-        self.n_features_in_ = X.shape[1]
         return self
 
     @staticmethod
@@ -147,7 +149,9 @@ class SubjectiveClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
             The predicted probabilities.
         """
         check_is_fitted(self, ["posterior_matrix_"])
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        _check_n_features(self, X, reset=False)
+
         y_hats = self.estimator_.predict_proba(X)  # these are ignorant of the prior
 
         if self.evidence == "predict_proba":
@@ -171,7 +175,9 @@ class SubjectiveClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator):
             The predicted class.
         """
         check_is_fitted(self, ["posterior_matrix_"])
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        _check_n_features(self, X, reset=False)
+
         return self.classes_[self.predict_proba(X).argmax(axis=1)]
 
     @property

--- a/sklego/meta/thresholder.py
+++ b/sklego/meta/thresholder.py
@@ -5,10 +5,9 @@ import numpy as np
 from sklearn import clone
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.exceptions import NotFittedError
-from sklearn.utils.multiclass import type_of_target
-from sklearn.utils.validation import _check_sample_weight, check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+from sklearn.utils.validation import _check_sample_weight, check_is_fitted, check_X_y
 
+from sklego._sklearn_compat import _check_n_features, check_array, type_of_target
 from sklego.base import ProbabilisticClassifier
 
 
@@ -99,13 +98,13 @@ class Thresholder(ClassifierMixin, BaseEstimator):
             raise ValueError("The Thresholder meta model only works on classification models with .predict_proba.")
 
         if self.check_input:
-            X, y = validate_data(self, X=X, y=y, ensure_all_finite=False, ensure_min_features=0, reset=True)
+            X, y = check_X_y(X, y, estimator=self, ensure_all_finite=False, ensure_min_features=0)
 
         _check_n_features(self, X, reset=True)
         self._handle_refit(X, y, sample_weight)
 
         self.classes_ = self.estimator_.classes_
-        y_type = type_of_target(y, input_name="y")
+        y_type = type_of_target(y, input_name="y", raise_unknown=True)
         if y_type != "binary":
             raise ValueError("Only binary classification is supported. The type of the target " f"is {y_type}.")
 
@@ -126,7 +125,7 @@ class Thresholder(ClassifierMixin, BaseEstimator):
         """
         check_is_fitted(self, ["classes_", "estimator_"])
         if self.check_input:
-            X = validate_data(self, X=X, ensure_min_features=0, ensure_all_finite=False, reset=False)
+            X = check_array(X, estimator=self, ensure_min_features=0, ensure_all_finite=False)
         _check_n_features(self, X, reset=False)
 
         predicate = self.estimator_.predict_proba(X)[:, 1] > self.threshold
@@ -136,7 +135,7 @@ class Thresholder(ClassifierMixin, BaseEstimator):
         """Alias for `.predict_proba()` method of the underlying estimator."""
         check_is_fitted(self, ["classes_", "estimator_"])
         if self.check_input:
-            X = validate_data(self, X=X, ensure_min_features=0, ensure_all_finite=False, reset=False)
+            X = check_array(X, estimator=self, ensure_min_features=0, ensure_all_finite=False)
         _check_n_features(self, X, reset=False)
 
         return self.estimator_.predict_proba(X)
@@ -145,7 +144,7 @@ class Thresholder(ClassifierMixin, BaseEstimator):
         """Alias for `.score()` method of the underlying estimator."""
         check_is_fitted(self, ["classes_", "estimator_"])
         if self.check_input:
-            X = validate_data(self, X=X, ensure_min_features=0, ensure_all_finite=False, reset=False)
+            X = check_array(X, estimator=self, ensure_min_features=0, ensure_all_finite=False)
         _check_n_features(self, X, reset=False)
 
         return self.estimator_.score(X, y)

--- a/sklego/meta/thresholder.py
+++ b/sklego/meta/thresholder.py
@@ -5,7 +5,9 @@ import numpy as np
 from sklearn import clone
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.exceptions import NotFittedError
-from sklearn.utils.validation import _check_sample_weight, check_is_fitted, check_X_y
+from sklearn.utils.multiclass import type_of_target
+from sklearn.utils.validation import _check_sample_weight, check_is_fitted
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 from sklego.base import ProbabilisticClassifier
 
@@ -97,14 +99,15 @@ class Thresholder(ClassifierMixin, BaseEstimator):
             raise ValueError("The Thresholder meta model only works on classification models with .predict_proba.")
 
         if self.check_input:
-            X, y = check_X_y(X, y, force_all_finite=False, ensure_min_features=0, estimator=self)
+            X, y = validate_data(self, X=X, y=y, ensure_all_finite=False, ensure_min_features=0, reset=True)
 
+        _check_n_features(self, X, reset=True)
         self._handle_refit(X, y, sample_weight)
 
-        self.n_features_in_ = X.shape[1]
         self.classes_ = self.estimator_.classes_
-        if len(self.classes_) != 2:
-            raise ValueError("The `Thresholder` meta model only works on models with two classes.")
+        y_type = type_of_target(y, input_name="y")
+        if y_type != "binary":
+            raise ValueError("Only binary classification is supported. The type of the target " f"is {y_type}.")
 
         return self
 
@@ -122,20 +125,37 @@ class Thresholder(ClassifierMixin, BaseEstimator):
             The predicted values.
         """
         check_is_fitted(self, ["classes_", "estimator_"])
+        if self.check_input:
+            X = validate_data(self, X=X, ensure_min_features=0, ensure_all_finite=False, reset=False)
+        _check_n_features(self, X, reset=False)
+
         predicate = self.estimator_.predict_proba(X)[:, 1] > self.threshold
         return np.where(predicate, self.classes_[1], self.classes_[0])
 
     def predict_proba(self, X):
         """Alias for `.predict_proba()` method of the underlying estimator."""
         check_is_fitted(self, ["classes_", "estimator_"])
+        if self.check_input:
+            X = validate_data(self, X=X, ensure_min_features=0, ensure_all_finite=False, reset=False)
+        _check_n_features(self, X, reset=False)
+
         return self.estimator_.predict_proba(X)
 
     def score(self, X, y):
         """Alias for `.score()` method of the underlying estimator."""
         check_is_fitted(self, ["classes_", "estimator_"])
+        if self.check_input:
+            X = validate_data(self, X=X, ensure_min_features=0, ensure_all_finite=False, reset=False)
+        _check_n_features(self, X, reset=False)
+
         return self.estimator_.score(X, y)
 
     def _more_tags(self):
         return {
             "binary_only": True,
         }
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.classifier_tags.multi_class = False
+        return tags

--- a/sklego/meta/thresholder.py
+++ b/sklego/meta/thresholder.py
@@ -5,9 +5,9 @@ import numpy as np
 from sklearn import clone
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.exceptions import NotFittedError
-from sklearn.utils.validation import _check_sample_weight, check_is_fitted, check_X_y
+from sklearn.utils.validation import _check_sample_weight, check_is_fitted
 
-from sklego._sklearn_compat import _check_n_features, check_array, type_of_target
+from sklego._sklearn_compat import _check_n_features, check_array, check_X_y, type_of_target
 from sklego.base import ProbabilisticClassifier
 
 

--- a/sklego/meta/zero_inflated_regressor.py
+++ b/sklego/meta/zero_inflated_regressor.py
@@ -5,9 +5,9 @@ import numpy as np
 from sklearn.base import BaseEstimator, MetaEstimatorMixin, RegressorMixin, clone, is_classifier, is_regressor
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.metaestimators import available_if
-from sklearn.utils.validation import _check_sample_weight, check_is_fitted, check_X_y
+from sklearn.utils.validation import _check_sample_weight, check_is_fitted
 
-from sklego._sklearn_compat import _check_n_features, check_array
+from sklego._sklearn_compat import _check_n_features, check_array, check_X_y
 
 
 class ZeroInflatedRegressor(RegressorMixin, MetaEstimatorMixin, BaseEstimator):

--- a/sklego/meta/zero_inflated_regressor.py
+++ b/sklego/meta/zero_inflated_regressor.py
@@ -99,7 +99,8 @@ class ZeroInflatedRegressor(RegressorMixin, BaseEstimator, MetaEstimatorMixin):
             If all train target entirely consists of zeros and `handle_zero="error"`
         """
         X, y = check_X_y(X, y)
-        self._check_n_features(X, reset=True)
+        self.n_features_in_ = X.shape[1]
+
         if not is_classifier(self.classifier):
             raise ValueError(
                 f"`classifier` has to be a classifier. Received instance of {type(self.classifier)} instead."
@@ -173,9 +174,12 @@ class ZeroInflatedRegressor(RegressorMixin, BaseEstimator, MetaEstimatorMixin):
         array-like of shape (n_samples,)
             The predicted values.
         """
-        check_is_fitted(self)
+        check_is_fitted(self, ["n_features_in_", "classifier_", "regressor_"])
         X = check_array(X)
-        self._check_n_features(X, reset=False)
+
+        if X.shape[1] != self.n_features_in_:
+            msg = f"Unexpected input dimension {X.shape[1]}, expected {self.n_features_in_}"
+            raise ValueError(msg)
 
         output = np.zeros(len(X))
         non_zero_indices = np.where(self.classifier_.predict(X))[0]
@@ -211,9 +215,12 @@ class ZeroInflatedRegressor(RegressorMixin, BaseEstimator, MetaEstimatorMixin):
             The predicted risk.
         """
 
-        check_is_fitted(self)
+        check_is_fitted(self, ["n_features_in_", "classifier_", "regressor_"])
         X = check_array(X)
-        self._check_n_features(X, reset=True)
+
+        if X.shape[1] != self.n_features_in_:
+            msg = f"Unexpected input dimension {X.shape[1]}, expected {self.n_features_in_}"
+            raise ValueError(msg)
 
         non_zero_proba = self.classifier_.predict_proba(X)[:, 1]
         expected_impact = self.regressor_.predict(X)

--- a/sklego/meta/zero_inflated_regressor.py
+++ b/sklego/meta/zero_inflated_regressor.py
@@ -5,8 +5,9 @@ import numpy as np
 from sklearn.base import BaseEstimator, MetaEstimatorMixin, RegressorMixin, clone, is_classifier, is_regressor
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.metaestimators import available_if
-from sklearn.utils.validation import _check_sample_weight, check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+from sklearn.utils.validation import _check_sample_weight, check_is_fitted, check_X_y
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class ZeroInflatedRegressor(RegressorMixin, MetaEstimatorMixin, BaseEstimator):
@@ -99,7 +100,7 @@ class ZeroInflatedRegressor(RegressorMixin, MetaEstimatorMixin, BaseEstimator):
             If `regressor` is not a regressor
             If all train target entirely consists of zeros and `handle_zero="error"`
         """
-        X, y = validate_data(self, X=X, y=y, reset=True)
+        X, y = check_X_y(estimator=self, X=X, y=y)
         _check_n_features(self, X, reset=True)
 
         if not is_classifier(self.classifier):
@@ -176,7 +177,7 @@ class ZeroInflatedRegressor(RegressorMixin, MetaEstimatorMixin, BaseEstimator):
             The predicted values.
         """
         check_is_fitted(self, ["n_features_in_", "classifier_", "regressor_"])
-        X = validate_data(self, X=X, reset=False)
+        X = check_array(X, estimator=self)
         _check_n_features(self, X, reset=False)
 
         output = np.zeros(len(X))
@@ -214,7 +215,7 @@ class ZeroInflatedRegressor(RegressorMixin, MetaEstimatorMixin, BaseEstimator):
         """
 
         check_is_fitted(self, ["n_features_in_", "classifier_", "regressor_"])
-        X = validate_data(self, X=X, reset=False)
+        X = check_array(X, estimator=self)
         _check_n_features(self, X, reset=False)
 
         non_zero_proba = self.classifier_.predict_proba(X)[:, 1]

--- a/sklego/mixture/bayesian_gmm_classifier.py
+++ b/sklego/mixture/bayesian_gmm_classifier.py
@@ -3,9 +3,9 @@ from scipy.special import softmax
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.mixture import BayesianGaussianMixture
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
 
-from sklego._sklearn_compat import _check_n_features, check_array
+from sklego._sklearn_compat import _check_n_features, check_array, check_X_y
 
 
 class BayesianGMMClassifier(ClassifierMixin, BaseEstimator):

--- a/sklego/mixture/bayesian_gmm_classifier.py
+++ b/sklego/mixture/bayesian_gmm_classifier.py
@@ -2,9 +2,9 @@ import numpy as np
 from scipy.special import softmax
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.mixture import BayesianGaussianMixture
-from sklearn.utils import check_X_y
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import FLOAT_DTYPES, check_array, check_is_fitted
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 
 class BayesianGMMClassifier(ClassifierMixin, BaseEstimator):
@@ -77,9 +77,10 @@ class BayesianGMMClassifier(ClassifierMixin, BaseEstimator):
         self : BayesianGMMClassifier
             The fitted estimator.
         """
-        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
+        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
         if X.ndim == 1:
             X = np.expand_dims(X, 1)
+        _check_n_features(self, X, reset=True)
 
         self.gmms_ = {}
         self.classes_ = unique_labels(y)
@@ -106,7 +107,6 @@ class BayesianGMMClassifier(ClassifierMixin, BaseEstimator):
             )
             self.gmms_[c] = mixture.fit(subset_x, subset_y)
 
-        self.n_features_in_ = X.shape[1]
         self.n_iter_ = sum(mixture.n_iter_ for mixture in self.gmms_.values())
 
         return self
@@ -125,7 +125,9 @@ class BayesianGMMClassifier(ClassifierMixin, BaseEstimator):
             The predicted data.
         """
         check_is_fitted(self, ["gmms_", "classes_"])
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        _check_n_features(self, X, reset=False)
+
         return self.classes_[self.predict_proba(X).argmax(axis=1)]
 
     def predict_proba(self, X):
@@ -141,8 +143,10 @@ class BayesianGMMClassifier(ClassifierMixin, BaseEstimator):
         array-like of shape (n_samples, n_classes)
             The predicted probabilities.
         """
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         check_is_fitted(self, ["gmms_", "classes_"])
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        _check_n_features(self, X, reset=False)
+
         res = np.zeros((X.shape[0], self.classes_.shape[0]))
         for idx, c in enumerate(self.classes_):
             res[:, idx] = self.gmms_[c].score_samples(X)

--- a/sklego/mixture/bayesian_gmm_classifier.py
+++ b/sklego/mixture/bayesian_gmm_classifier.py
@@ -3,8 +3,9 @@ from scipy.special import softmax
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.mixture import BayesianGaussianMixture
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class BayesianGMMClassifier(ClassifierMixin, BaseEstimator):
@@ -77,7 +78,7 @@ class BayesianGMMClassifier(ClassifierMixin, BaseEstimator):
         self : BayesianGMMClassifier
             The fitted estimator.
         """
-        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
+        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         if X.ndim == 1:
             X = np.expand_dims(X, 1)
         _check_n_features(self, X, reset=True)
@@ -125,7 +126,7 @@ class BayesianGMMClassifier(ClassifierMixin, BaseEstimator):
             The predicted data.
         """
         check_is_fitted(self, ["gmms_", "classes_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
 
         return self.classes_[self.predict_proba(X).argmax(axis=1)]
@@ -144,7 +145,7 @@ class BayesianGMMClassifier(ClassifierMixin, BaseEstimator):
             The predicted probabilities.
         """
         check_is_fitted(self, ["gmms_", "classes_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
 
         res = np.zeros((X.shape[0], self.classes_.shape[0]))

--- a/sklego/mixture/bayesian_gmm_detector.py
+++ b/sklego/mixture/bayesian_gmm_detector.py
@@ -6,7 +6,8 @@ from scipy.stats import gaussian_kde
 from sklearn.base import BaseEstimator, OutlierMixin
 from sklearn.mixture import BayesianGaussianMixture
 from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class BayesianGMMOutlierDetector(OutlierMixin, BaseEstimator):
@@ -110,7 +111,7 @@ class BayesianGMMOutlierDetector(OutlierMixin, BaseEstimator):
         """
 
         # GMM sometimes throws an error if you don't do this
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=True)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         if len(X.shape) == 1:
             X = np.expand_dims(X, 1)
 
@@ -162,7 +163,7 @@ class BayesianGMMOutlierDetector(OutlierMixin, BaseEstimator):
 
     def score_samples(self, X):
         """Compute the log likelihood for each sample and return the negative value."""
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
 
         check_is_fitted(self, ["gmm_", "likelihood_threshold_"])

--- a/sklego/mixture/gmm_classifier.py
+++ b/sklego/mixture/gmm_classifier.py
@@ -3,8 +3,9 @@ from scipy.special import softmax
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.mixture import GaussianMixture
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class GMMClassifier(ClassifierMixin, BaseEstimator):
@@ -72,7 +73,7 @@ class GMMClassifier(ClassifierMixin, BaseEstimator):
         self : GMMClassifier
             The fitted estimator.
         """
-        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
+        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         if X.ndim == 1:
             X = np.expand_dims(X, 1)
         _check_n_features(self, X, reset=True)
@@ -117,7 +118,7 @@ class GMMClassifier(ClassifierMixin, BaseEstimator):
             The predicted data.
         """
         check_is_fitted(self, ["gmms_", "classes_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
 
         return self.classes_[self.predict_proba(X).argmax(axis=1)]
@@ -136,7 +137,7 @@ class GMMClassifier(ClassifierMixin, BaseEstimator):
             The predicted probabilities.
         """
         check_is_fitted(self, ["gmms_", "classes_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
 
         res = np.zeros((X.shape[0], self.classes_.shape[0]))

--- a/sklego/mixture/gmm_classifier.py
+++ b/sklego/mixture/gmm_classifier.py
@@ -3,9 +3,9 @@ from scipy.special import softmax
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.mixture import GaussianMixture
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
 
-from sklego._sklearn_compat import _check_n_features, check_array
+from sklego._sklearn_compat import _check_n_features, check_array, check_X_y
 
 
 class GMMClassifier(ClassifierMixin, BaseEstimator):

--- a/sklego/mixture/gmm_classifier.py
+++ b/sklego/mixture/gmm_classifier.py
@@ -2,9 +2,9 @@ import numpy as np
 from scipy.special import softmax
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.mixture import GaussianMixture
-from sklearn.utils import check_X_y
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import FLOAT_DTYPES, check_array, check_is_fitted
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 
 class GMMClassifier(ClassifierMixin, BaseEstimator):
@@ -72,9 +72,10 @@ class GMMClassifier(ClassifierMixin, BaseEstimator):
         self : GMMClassifier
             The fitted estimator.
         """
-        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
+        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
         if X.ndim == 1:
             X = np.expand_dims(X, 1)
+        _check_n_features(self, X, reset=True)
 
         self.gmms_ = {}
         self.classes_ = unique_labels(y)
@@ -98,7 +99,6 @@ class GMMClassifier(ClassifierMixin, BaseEstimator):
             )
             self.gmms_[c] = mixture.fit(subset_x, subset_y)
 
-        self.n_features_in_ = X.shape[1]
         self.n_iter_ = sum(mixture.n_iter_ for mixture in self.gmms_.values())
 
         return self
@@ -117,7 +117,9 @@ class GMMClassifier(ClassifierMixin, BaseEstimator):
             The predicted data.
         """
         check_is_fitted(self, ["gmms_", "classes_"])
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        _check_n_features(self, X, reset=False)
+
         return self.classes_[self.predict_proba(X).argmax(axis=1)]
 
     def predict_proba(self, X):
@@ -133,8 +135,10 @@ class GMMClassifier(ClassifierMixin, BaseEstimator):
         array-like of shape (n_samples, n_classes)
             The predicted probabilities.
         """
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         check_is_fitted(self, ["gmms_", "classes_"])
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        _check_n_features(self, X, reset=False)
+
         res = np.zeros((X.shape[0], self.classes_.shape[0]))
         for idx, c in enumerate(self.classes_):
             res[:, idx] = self.gmms_[c].score_samples(X)

--- a/sklego/mixture/gmm_outlier_detector.py
+++ b/sklego/mixture/gmm_outlier_detector.py
@@ -6,7 +6,8 @@ from scipy.stats import gaussian_kde
 from sklearn.base import BaseEstimator, OutlierMixin
 from sklearn.mixture import GaussianMixture
 from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class GMMOutlierDetector(OutlierMixin, BaseEstimator):
@@ -103,7 +104,7 @@ class GMMOutlierDetector(OutlierMixin, BaseEstimator):
             - If `method` is not in `["quantile", "stddev"]`.
         """
         # GMM sometimes throws an error if you don't do this
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=True)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         if X.ndim == 1:
             X = np.expand_dims(X, 1)
         _check_n_features(self, X, reset=True)
@@ -153,7 +154,7 @@ class GMMOutlierDetector(OutlierMixin, BaseEstimator):
     def score_samples(self, X):
         """Compute the log likelihood for each sample and return the negative value."""
         check_is_fitted(self, ["gmm_", "likelihood_threshold_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
 
         if X.ndim == 1:
             X = np.expand_dims(X, 1)

--- a/sklego/mixture/gmm_outlier_detector.py
+++ b/sklego/mixture/gmm_outlier_detector.py
@@ -5,7 +5,8 @@ from scipy.optimize import minimize_scalar
 from scipy.stats import gaussian_kde
 from sklearn.base import BaseEstimator, OutlierMixin
 from sklearn.mixture import GaussianMixture
-from sklearn.utils.validation import FLOAT_DTYPES, check_array, check_is_fitted
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 
 class GMMOutlierDetector(OutlierMixin, BaseEstimator):
@@ -102,9 +103,10 @@ class GMMOutlierDetector(OutlierMixin, BaseEstimator):
             - If `method` is not in `["quantile", "stddev"]`.
         """
         # GMM sometimes throws an error if you don't do this
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
-        if len(X.shape) == 1:
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=True)
+        if X.ndim == 1:
             X = np.expand_dims(X, 1)
+        _check_n_features(self, X, reset=True)
 
         if (self.method == "quantile") and ((self.threshold > 1) or (self.threshold < 0)):
             raise ValueError(f"Threshold {self.threshold} with method {self.method} needs to be 0 < threshold < 1")
@@ -150,10 +152,12 @@ class GMMOutlierDetector(OutlierMixin, BaseEstimator):
 
     def score_samples(self, X):
         """Compute the log likelihood for each sample and return the negative value."""
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         check_is_fitted(self, ["gmm_", "likelihood_threshold_"])
-        if len(X.shape) == 1:
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+
+        if X.ndim == 1:
             X = np.expand_dims(X, 1)
+        _check_n_features(self, X, reset=False)
 
         return self.gmm_.score_samples(X)
 

--- a/sklego/model_selection.py
+++ b/sklego/model_selection.py
@@ -7,8 +7,9 @@ import narwhals.stable.v1 as nw
 import numpy as np
 import pandas as pd
 from sklearn.exceptions import NotFittedError
-from sklearn.model_selection._split import _BaseKFold, check_array
+from sklearn.model_selection._split import _BaseKFold
 from sklearn.utils.validation import indexable
+from sklearn_compat.utils.validation import validate_data
 
 from sklego.base import Clusterer
 from sklego.common import sliding_window
@@ -320,7 +321,7 @@ class ClusterFoldValidation:
             Train and test indices of the same fold.
         """
 
-        X = check_array(X)
+        X = validate_data(self, X=X, reset=True)
 
         if not self._method_is_fitted(X):
             self.cluster_method.fit(X)

--- a/sklego/model_selection.py
+++ b/sklego/model_selection.py
@@ -9,8 +9,8 @@ import pandas as pd
 from sklearn.exceptions import NotFittedError
 from sklearn.model_selection._split import _BaseKFold
 from sklearn.utils.validation import indexable
-from sklearn_compat.utils.validation import validate_data
 
+from sklego._sklearn_compat import check_array
 from sklego.base import Clusterer
 from sklego.common import sliding_window
 
@@ -321,7 +321,7 @@ class ClusterFoldValidation:
             Train and test indices of the same fold.
         """
 
-        X = validate_data(self, X=X, reset=True)
+        X = check_array(X, estimator=self)
 
         if not self._method_is_fitted(X):
             self.cluster_method.fit(X)

--- a/sklego/naive_bayes.py
+++ b/sklego/naive_bayes.py
@@ -4,8 +4,9 @@ import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.mixture import BayesianGaussianMixture, GaussianMixture
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class GaussianMixtureNB(ClassifierMixin, BaseEstimator):
@@ -73,7 +74,7 @@ class GaussianMixtureNB(ClassifierMixin, BaseEstimator):
         self : GaussianMixtureNB
             The fitted estimator.
         """
-        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
+        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         if X.ndim == 1:
             X = np.expand_dims(X, 1)
 
@@ -119,7 +120,7 @@ class GaussianMixtureNB(ClassifierMixin, BaseEstimator):
             The predicted data.
         """
         check_is_fitted(self, ["gmms_", "classes_", "n_features_in_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
         # if self.n_features_in_ != X.shape[1]:
         #     raise ValueError(f"number of columns {X.shape[1]} does not match fit size {self.n_features_in_}")
@@ -141,7 +142,7 @@ class GaussianMixtureNB(ClassifierMixin, BaseEstimator):
             The predicted probabilities.
         """
         check_is_fitted(self, ["gmms_", "classes_", "n_features_in_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X=X, reset=False)
 
         probs = np.zeros((X.shape[0], len(self.classes_)))
@@ -239,7 +240,7 @@ class BayesianGaussianMixtureNB(ClassifierMixin, BaseEstimator):
         self : BayesianGaussianMixtureNB
             The fitted estimator.
         """
-        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
+        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         if X.ndim == 1:
             X = np.expand_dims(X, 1)
 
@@ -289,7 +290,7 @@ class BayesianGaussianMixtureNB(ClassifierMixin, BaseEstimator):
             The predicted data.
         """
         check_is_fitted(self, ["gmms_", "classes_", "n_features_in_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
 
         _check_n_features(self, X, reset=False)
 
@@ -310,7 +311,7 @@ class BayesianGaussianMixtureNB(ClassifierMixin, BaseEstimator):
             The predicted probabilities.
         """
         check_is_fitted(self, ["gmms_", "classes_", "n_features_in_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
 
         probs = np.zeros((X.shape[0], len(self.classes_)))

--- a/sklego/naive_bayes.py
+++ b/sklego/naive_bayes.py
@@ -3,9 +3,9 @@ from warnings import warn
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.mixture import BayesianGaussianMixture, GaussianMixture
-from sklearn.utils import check_X_y
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import FLOAT_DTYPES, check_array, check_is_fitted
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 
 class GaussianMixtureNB(ClassifierMixin, BaseEstimator):
@@ -73,9 +73,11 @@ class GaussianMixtureNB(ClassifierMixin, BaseEstimator):
         self : GaussianMixtureNB
             The fitted estimator.
         """
-        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
+        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
         if X.ndim == 1:
             X = np.expand_dims(X, 1)
+
+        _check_n_features(self, X, reset=True)
 
         self.gmms_ = {}
         self.classes_ = unique_labels(y)
@@ -117,10 +119,10 @@ class GaussianMixtureNB(ClassifierMixin, BaseEstimator):
             The predicted data.
         """
         check_is_fitted(self, ["gmms_", "classes_", "n_features_in_"])
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
-
-        if self.n_features_in_ != X.shape[1]:
-            raise ValueError(f"number of columns {X.shape[1]} does not match fit size {self.n_features_in_}")
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        _check_n_features(self, X, reset=False)
+        # if self.n_features_in_ != X.shape[1]:
+        #     raise ValueError(f"number of columns {X.shape[1]} does not match fit size {self.n_features_in_}")
 
         return self.classes_[self.predict_proba(X).argmax(axis=1)]
 
@@ -139,10 +141,9 @@ class GaussianMixtureNB(ClassifierMixin, BaseEstimator):
             The predicted probabilities.
         """
         check_is_fitted(self, ["gmms_", "classes_", "n_features_in_"])
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
-        if self.n_features_in_ != X.shape[1]:
-            raise ValueError(f"number of columns {X.shape[1]} does not match fit size {self.n_features_in_}")
-        check_is_fitted(self, ["gmms_", "classes_"])
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        _check_n_features(self, X=X, reset=False)
+
         probs = np.zeros((X.shape[0], len(self.classes_)))
         for k, v in self.gmms_.items():
             class_idx = np.argmax(self.classes_ == k)
@@ -238,10 +239,11 @@ class BayesianGaussianMixtureNB(ClassifierMixin, BaseEstimator):
         self : BayesianGaussianMixtureNB
             The fitted estimator.
         """
-        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
+        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
         if X.ndim == 1:
             X = np.expand_dims(X, 1)
 
+        _check_n_features(self, X, reset=True)
         self.gmms_ = {}
         self.classes_ = unique_labels(y)
         self.n_features_in_ = X.shape[1]
@@ -287,10 +289,9 @@ class BayesianGaussianMixtureNB(ClassifierMixin, BaseEstimator):
             The predicted data.
         """
         check_is_fitted(self, ["gmms_", "classes_", "n_features_in_"])
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
 
-        if self.n_features_in_ != X.shape[1]:
-            raise ValueError(f"number of columns {X.shape[1]} does not match fit size {self.n_features_in_}")
+        _check_n_features(self, X, reset=False)
 
         return self.classes_[self.predict_proba(X).argmax(axis=1)]
 
@@ -309,10 +310,9 @@ class BayesianGaussianMixtureNB(ClassifierMixin, BaseEstimator):
             The predicted probabilities.
         """
         check_is_fitted(self, ["gmms_", "classes_", "n_features_in_"])
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
-        if self.n_features_in_ != X.shape[1]:
-            raise ValueError(f"number of columns {X.shape[1]} does not match fit size {self.n_features_in_}")
-        check_is_fitted(self, ["gmms_", "classes_"])
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        _check_n_features(self, X, reset=False)
+
         probs = np.zeros((X.shape[0], len(self.classes_)))
         for k, v in self.gmms_.items():
             class_idx = np.argmax(self.classes_ == k)

--- a/sklego/naive_bayes.py
+++ b/sklego/naive_bayes.py
@@ -4,9 +4,9 @@ import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.mixture import BayesianGaussianMixture, GaussianMixture
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
 
-from sklego._sklearn_compat import _check_n_features, check_array
+from sklego._sklearn_compat import _check_n_features, check_array, check_X_y
 
 
 class GaussianMixtureNB(ClassifierMixin, BaseEstimator):

--- a/sklego/naive_bayes.py
+++ b/sklego/naive_bayes.py
@@ -118,6 +118,10 @@ class GaussianMixtureNB(ClassifierMixin, BaseEstimator):
         """
         check_is_fitted(self, ["gmms_", "classes_", "n_features_in_"])
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
+
+        if self.n_features_in_ != X.shape[1]:
+            raise ValueError(f"number of columns {X.shape[1]} does not match fit size {self.n_features_in_}")
+
         return self.classes_[self.predict_proba(X).argmax(axis=1)]
 
     def predict_proba(self, X: np.ndarray):
@@ -284,6 +288,10 @@ class BayesianGaussianMixtureNB(ClassifierMixin, BaseEstimator):
         """
         check_is_fitted(self, ["gmms_", "classes_", "n_features_in_"])
         X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
+
+        if self.n_features_in_ != X.shape[1]:
+            raise ValueError(f"number of columns {X.shape[1]} does not match fit size {self.n_features_in_}")
+
         return self.classes_[self.predict_proba(X).argmax(axis=1)]
 
     def predict_proba(self, X: np.ndarray):

--- a/sklego/neighbors.py
+++ b/sklego/neighbors.py
@@ -2,9 +2,9 @@ import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.neighbors import KernelDensity
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
 
-from sklego._sklearn_compat import _check_n_features, check_array
+from sklego._sklearn_compat import _check_n_features, check_array, check_X_y
 
 
 class BayesianKernelDensityClassifier(ClassifierMixin, BaseEstimator):

--- a/sklego/neighbors.py
+++ b/sklego/neighbors.py
@@ -1,9 +1,9 @@
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.neighbors import KernelDensity
-from sklearn.utils import check_X_y
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import FLOAT_DTYPES, check_array, check_is_fitted
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 
 class BayesianKernelDensityClassifier(ClassifierMixin, BaseEstimator):
@@ -62,7 +62,8 @@ class BayesianKernelDensityClassifier(ClassifierMixin, BaseEstimator):
         self : BayesianKernelDensityClassifier
             The fitted estimator.
         """
-        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
+        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
+        _check_n_features(self, X, reset=True)
 
         self.classes_ = unique_labels(y)
         self.models_, self.priors_logp_ = {}, {}
@@ -103,8 +104,9 @@ class BayesianKernelDensityClassifier(ClassifierMixin, BaseEstimator):
         array-like of shape (n_samples, n_classes)
             The predicted probabilities for each class, ordered as in `self.classes_`.
         """
-        check_is_fitted(self)
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
+        check_is_fitted(self, ["classes_", "models_"])
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        _check_n_features(self, X, reset=False)
 
         log_prior = np.array([self.priors_logp_[target_label] for target_label in self.classes_])
 
@@ -129,7 +131,8 @@ class BayesianKernelDensityClassifier(ClassifierMixin, BaseEstimator):
         array-like of shape (n_samples,)
             The predicted data.
         """
-        check_is_fitted(self)
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
+        check_is_fitted(self, ["classes_", "models_"])
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        _check_n_features(self, X, reset=False)
 
         return self.classes_[np.argmax(self.predict_proba(X), 1)]

--- a/sklego/neighbors.py
+++ b/sklego/neighbors.py
@@ -2,8 +2,9 @@ import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.neighbors import KernelDensity
 from sklearn.utils.multiclass import unique_labels
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_X_y
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class BayesianKernelDensityClassifier(ClassifierMixin, BaseEstimator):
@@ -62,7 +63,7 @@ class BayesianKernelDensityClassifier(ClassifierMixin, BaseEstimator):
         self : BayesianKernelDensityClassifier
             The fitted estimator.
         """
-        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
+        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=True)
 
         self.classes_ = unique_labels(y)
@@ -105,7 +106,7 @@ class BayesianKernelDensityClassifier(ClassifierMixin, BaseEstimator):
             The predicted probabilities for each class, ordered as in `self.classes_`.
         """
         check_is_fitted(self, ["classes_", "models_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
 
         log_prior = np.array([self.priors_logp_[target_label] for target_label in self.classes_])
@@ -132,7 +133,7 @@ class BayesianKernelDensityClassifier(ClassifierMixin, BaseEstimator):
             The predicted data.
         """
         check_is_fitted(self, ["classes_", "models_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
 
         return self.classes_[np.argmax(self.predict_proba(X), 1)]

--- a/sklego/preprocessing/columncapper.py
+++ b/sklego/preprocessing/columncapper.py
@@ -96,9 +96,6 @@ class ColumnCapper(TransformerMixin, BaseEstimator):
         discard_infs=False,
         copy=True,
     ):
-        self._check_quantile_range(quantile_range)
-        self._check_interpolation(interpolation)
-
         self.quantile_range = quantile_range
         self.interpolation = interpolation
         self.discard_infs = discard_infs
@@ -124,6 +121,8 @@ class ColumnCapper(TransformerMixin, BaseEstimator):
         ValueError
             If `X` contains non-numeric columns.
         """
+        self._check_quantile_range(self.quantile_range)
+        self._check_interpolation(self.interpolation)
         X = check_array(X, copy=True, force_all_finite=False, dtype=FLOAT_DTYPES, estimator=self)
 
         # If X contains infs, we need to replace them by nans before computing quantiles

--- a/sklego/preprocessing/columncapper.py
+++ b/sklego/preprocessing/columncapper.py
@@ -3,7 +3,8 @@ from warnings import warn
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class ColumnCapper(TransformerMixin, BaseEstimator):
@@ -124,7 +125,7 @@ class ColumnCapper(TransformerMixin, BaseEstimator):
         self._check_quantile_range(self.quantile_range)
         self._check_interpolation(self.interpolation)
 
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, copy=True, ensure_all_finite=False, reset=True)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES, copy=True, ensure_all_finite=False)
         _check_n_features(self, X, reset=True)
 
         # If X contains infs, we need to replace them by nans before computing quantiles
@@ -161,7 +162,7 @@ class ColumnCapper(TransformerMixin, BaseEstimator):
             If the number of columns from `X` differs from the number of columns when fitting.
         """
         check_is_fitted(self, ["quantiles_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, copy=self.copy, ensure_all_finite=False, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES, copy=self.copy, ensure_all_finite=False)
         _check_n_features(self, X, reset=False)
 
         if self.discard_infs:

--- a/sklego/preprocessing/dictmapper.py
+++ b/sklego/preprocessing/dictmapper.py
@@ -3,7 +3,8 @@ from warnings import warn
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class DictMapper(TransformerMixin, BaseEstimator):
@@ -74,7 +75,7 @@ class DictMapper(TransformerMixin, BaseEstimator):
         self : DictMapper
             The fitted transformer.
         """
-        X = validate_data(self, X=X, copy=True, dtype=None, ensure_2d=True, ensure_all_finite=False, reset=True)
+        X = check_array(X, estimator=self, copy=True, dtype=None, ensure_2d=True, ensure_all_finite=False)
         _check_n_features(self, X, reset=True)
 
         return self
@@ -98,7 +99,7 @@ class DictMapper(TransformerMixin, BaseEstimator):
             If the number of columns from `X` differs from the number of columns when fitting.
         """
         check_is_fitted(self, ["n_features_in_"])
-        X = validate_data(self, X=X, copy=True, dtype=None, ensure_2d=True, ensure_all_finite=False, reset=False)
+        X = check_array(X, estimator=self, copy=True, dtype=None, ensure_2d=True, ensure_all_finite=False)
         _check_n_features(self, X, reset=False)
         return np.vectorize(self.mapper.get, otypes=[int])(X, self.default)
 

--- a/sklego/preprocessing/identitytransformer.py
+++ b/sklego/preprocessing/identitytransformer.py
@@ -1,6 +1,6 @@
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 
 class IdentityTransformer(TransformerMixin, BaseEstimator):
@@ -68,7 +68,8 @@ class IdentityTransformer(TransformerMixin, BaseEstimator):
             The fitted transformer.
         """
         if self.check_X:
-            X = check_array(X, copy=True, estimator=self)
+            X = validate_data(self, X=X, copy=True, reset=True)
+        _check_n_features(self, X, reset=True)
         self.n_samples_, self.n_features_in_ = X.shape
         return self
 
@@ -90,13 +91,11 @@ class IdentityTransformer(TransformerMixin, BaseEstimator):
         ValueError
             If the number of columns from `X` differs from the number of columns when fitting.
         """
-        if self.check_X:
-            X = check_array(X, copy=True, estimator=self)
         check_is_fitted(self, "n_features_in_")
-        if X.shape[1] != self.n_features_in_:
-            raise ValueError(
-                f"Wrong shape is passed to transform. Trained on {self.n_features_in_} cols got {X.shape[1]}"
-            )
+
+        if self.check_X:
+            X = validate_data(self, X=X, copy=True, reset=False)
+        _check_n_features(self, X, reset=False)
         return X
 
     @property

--- a/sklego/preprocessing/identitytransformer.py
+++ b/sklego/preprocessing/identitytransformer.py
@@ -1,6 +1,7 @@
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class IdentityTransformer(TransformerMixin, BaseEstimator):
@@ -68,7 +69,7 @@ class IdentityTransformer(TransformerMixin, BaseEstimator):
             The fitted transformer.
         """
         if self.check_X:
-            X = validate_data(self, X=X, copy=True, reset=True)
+            X = check_array(X, estimator=self, copy=True)
         _check_n_features(self, X, reset=True)
         self.n_samples_, self.n_features_in_ = X.shape
         return self
@@ -94,7 +95,7 @@ class IdentityTransformer(TransformerMixin, BaseEstimator):
         check_is_fitted(self, "n_features_in_")
 
         if self.check_X:
-            X = validate_data(self, X=X, copy=True, reset=False)
+            X = check_array(X, estimator=self, copy=True)
         _check_n_features(self, X, reset=False)
         return X
 

--- a/sklego/preprocessing/intervalencoder.py
+++ b/sklego/preprocessing/intervalencoder.py
@@ -9,8 +9,8 @@ from warnings import warn
 
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.utils import check_array, check_X_y
 from sklearn.utils.validation import check_is_fitted
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 
 def _mk_monotonic_average(xs, ys, intervals, method="increasing", **kwargs):
@@ -156,7 +156,9 @@ class IntervalEncoder(TransformerMixin, BaseEstimator):
 
         # these two matrices will have shape (columns, quantiles)
         # quantiles indicate where the interval split occurs
-        X, y = check_X_y(X, y, estimator=self)
+        X, y = validate_data(self, X=X, y=y, reset=True)
+        _check_n_features(self, X, reset=True)
+
         self.quantiles_ = np.zeros((X.shape[1], self.n_chunks))
         # heights indicate what heights these intervals will have
         self.heights_ = np.zeros((X.shape[1], self.n_chunks))
@@ -194,9 +196,9 @@ class IntervalEncoder(TransformerMixin, BaseEstimator):
             If the number of columns from `X` differs from the number of columns when fitting.
         """
         check_is_fitted(self, ["quantiles_", "heights_", "n_features_in_"])
-        X = check_array(X, estimator=self)
-        if X.shape[1] != self.n_features_in_:
-            raise ValueError(f"fitted on {self.n_features_in_} features but received {X.shape[1]}")
+        X = validate_data(self, X=X, reset=False)
+        _check_n_features(self, X, reset=False)
+
         transformed = np.zeros(X.shape)
         for col in range(transformed.shape[1]):
             transformed[:, col] = np.interp(X[:, col], self.quantiles_[col, :], self.heights_[col, :])

--- a/sklego/preprocessing/intervalencoder.py
+++ b/sklego/preprocessing/intervalencoder.py
@@ -9,8 +9,9 @@ from warnings import warn
 
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.utils.validation import check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+from sklearn.utils.validation import check_is_fitted, check_X_y
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 def _mk_monotonic_average(xs, ys, intervals, method="increasing", **kwargs):
@@ -156,7 +157,7 @@ class IntervalEncoder(TransformerMixin, BaseEstimator):
 
         # these two matrices will have shape (columns, quantiles)
         # quantiles indicate where the interval split occurs
-        X, y = validate_data(self, X=X, y=y, reset=True)
+        X, y = check_X_y(estimator=self, X=X, y=y)
         _check_n_features(self, X, reset=True)
 
         self.quantiles_ = np.zeros((X.shape[1], self.n_chunks))
@@ -196,7 +197,7 @@ class IntervalEncoder(TransformerMixin, BaseEstimator):
             If the number of columns from `X` differs from the number of columns when fitting.
         """
         check_is_fitted(self, ["quantiles_", "heights_", "n_features_in_"])
-        X = validate_data(self, X=X, reset=False)
+        X = check_array(X, estimator=self)
         _check_n_features(self, X, reset=False)
 
         transformed = np.zeros(X.shape)

--- a/sklego/preprocessing/intervalencoder.py
+++ b/sklego/preprocessing/intervalencoder.py
@@ -9,9 +9,9 @@ from warnings import warn
 
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.utils.validation import check_is_fitted, check_X_y
+from sklearn.utils.validation import check_is_fitted
 
-from sklego._sklearn_compat import _check_n_features, check_array
+from sklego._sklearn_compat import _check_n_features, check_array, check_X_y
 
 
 def _mk_monotonic_average(xs, ys, intervals, method="increasing", **kwargs):

--- a/sklego/preprocessing/monotonicspline.py
+++ b/sklego/preprocessing/monotonicspline.py
@@ -2,7 +2,8 @@ import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.preprocessing import SplineTransformer
 from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class MonotonicSplineTransformer(TransformerMixin, BaseEstimator):
@@ -52,7 +53,7 @@ class MonotonicSplineTransformer(TransformerMixin, BaseEstimator):
         ValueError
             If `X` contains non-numeric columns.
         """
-        X = validate_data(self, X=X, copy=True, ensure_all_finite=False, dtype=FLOAT_DTYPES, reset=True)
+        X = check_array(X, estimator=self, copy=True, ensure_all_finite=False, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=True)
         # If X contains infs, we need to replace them by nans before computing quantiles
         self.spline_transformer_ = {
@@ -81,7 +82,7 @@ class MonotonicSplineTransformer(TransformerMixin, BaseEstimator):
             If the number of columns from `X` differs from the number of columns when fitting.
         """
         check_is_fitted(self, "spline_transformer_")
-        X = validate_data(self, X=X, ensure_all_finite=False, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, ensure_all_finite=False, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
         out = []
         for col in range(X.shape[1]):

--- a/sklego/preprocessing/outlier_remover.py
+++ b/sklego/preprocessing/outlier_remover.py
@@ -1,6 +1,7 @@
 from sklearn import clone
 from sklearn.base import BaseEstimator
-from sklearn.utils.validation import check_array, check_is_fitted
+from sklearn.utils.validation import check_is_fitted
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 from sklego.common import TrainOnlyTransformerMixin
 
@@ -68,6 +69,7 @@ class OutlierRemover(TrainOnlyTransformerMixin, BaseEstimator):
         if self.refit:
             super().fit(X, y)
             self.estimator_.fit(X, y)
+        _check_n_features(self, X, reset=True)
         return self
 
     def transform_train(self, X):
@@ -84,6 +86,9 @@ class OutlierRemover(TrainOnlyTransformerMixin, BaseEstimator):
             The data with the outliers removed, where `n_not_outliers = n_samples - n_outliers`.
         """
         check_is_fitted(self, "estimator_")
+        _check_n_features(self, X, reset=False)
+
         predictions = self.estimator_.predict(X)
-        check_array(predictions, estimator=self.outlier_detector, ensure_2d=False)
+        validate_data(self.outlier_detector, X=predictions, ensure_2d=False, reset=False)
+
         return X[predictions != -1]

--- a/sklego/preprocessing/outlier_remover.py
+++ b/sklego/preprocessing/outlier_remover.py
@@ -1,8 +1,8 @@
 from sklearn import clone
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
 
+from sklego._sklearn_compat import _check_n_features, check_array
 from sklego.common import TrainOnlyTransformerMixin
 
 
@@ -89,6 +89,6 @@ class OutlierRemover(TrainOnlyTransformerMixin, BaseEstimator):
         _check_n_features(self, X, reset=False)
 
         predictions = self.estimator_.predict(X)
-        validate_data(self.outlier_detector, X=predictions, ensure_2d=False, reset=False)
+        check_array(predictions, estimator=self.outlier_detector, ensure_2d=False)
 
         return X[predictions != -1]

--- a/sklego/preprocessing/projections.py
+++ b/sklego/preprocessing/projections.py
@@ -2,8 +2,8 @@ import narwhals.stable.v1 as nw
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
 
+from sklego._sklearn_compat import _check_n_features, check_array
 from sklego.common import as_list
 
 
@@ -66,7 +66,7 @@ class OrthogonalTransformer(TransformerMixin, BaseEstimator):
         self : OrthogonalTransformer
             The fitted transformer.
         """
-        X = validate_data(self, X=X, ensure_min_samples=2, reset=True)
+        X = check_array(X, estimator=self, ensure_min_samples=2)
         _check_n_features(self, X, reset=True)
 
         # Q, R such that X = Q*R, with Q orthogonal, from which follows Q = X*inv(R)
@@ -99,7 +99,7 @@ class OrthogonalTransformer(TransformerMixin, BaseEstimator):
         else:
             check_is_fitted(self, ["inv_R_"])
 
-        X = validate_data(self, X=X, reset=False)
+        X = check_array(X, estimator=self)
         _check_n_features(self, X, reset=False)
 
         return X @ self.inv_R_ / self.normalization_vector_
@@ -235,7 +235,7 @@ class InformationFilter(TransformerMixin, BaseEstimator):
         """
         self._check_coltype(X)
         self.col_ids_ = [v if isinstance(v, int) else self._col_idx(X, v) for v in as_list(self.columns)]
-        X = validate_data(self, X=X, reset=True)
+        X = check_array(X, estimator=self)
         _check_n_features(self, X, reset=True)
 
         X_fair = X.copy()
@@ -271,7 +271,7 @@ class InformationFilter(TransformerMixin, BaseEstimator):
         """
         check_is_fitted(self, ["projection_", "col_ids_"])
         self._check_coltype(X)
-        X = validate_data(self, X=X, reset=False)
+        X = check_array(X, estimator=self)
         _check_n_features(self, X, reset=False)
 
         # apply the projection and remove the column we won't need

--- a/sklego/preprocessing/randomadder.py
+++ b/sklego/preprocessing/randomadder.py
@@ -1,9 +1,9 @@
 from warnings import warn
 
 from sklearn.base import BaseEstimator
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_random_state, check_X_y
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_random_state
 
-from sklego._sklearn_compat import _check_n_features, check_array
+from sklego._sklearn_compat import _check_n_features, check_array, check_X_y
 from sklego.common import TrainOnlyTransformerMixin
 
 

--- a/sklego/preprocessing/randomadder.py
+++ b/sklego/preprocessing/randomadder.py
@@ -1,9 +1,9 @@
 from warnings import warn
 
 from sklearn.base import BaseEstimator
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_random_state
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_random_state, check_X_y
 
+from sklego._sklearn_compat import _check_n_features, check_array
 from sklego.common import TrainOnlyTransformerMixin
 
 
@@ -69,7 +69,7 @@ class RandomAdder(TrainOnlyTransformerMixin, BaseEstimator):
             The fitted transformer.
         """
         super().fit(X, y)
-        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
+        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=True)
 
         return self
@@ -89,7 +89,7 @@ class RandomAdder(TrainOnlyTransformerMixin, BaseEstimator):
         """
         rs = check_random_state(self.random_state)
         check_is_fitted(self, ["n_features_in_"])
-        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
         _check_n_features(self, X, reset=False)
 
         return X + rs.normal(0, self.noise, size=X.shape)

--- a/sklego/preprocessing/randomadder.py
+++ b/sklego/preprocessing/randomadder.py
@@ -1,8 +1,8 @@
 from warnings import warn
 
 from sklearn.base import BaseEstimator
-from sklearn.utils import check_array, check_X_y
 from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, check_random_state
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 from sklego.common import TrainOnlyTransformerMixin
 
@@ -69,8 +69,8 @@ class RandomAdder(TrainOnlyTransformerMixin, BaseEstimator):
             The fitted transformer.
         """
         super().fit(X, y)
-        X, y = check_X_y(X, y, estimator=self, dtype=FLOAT_DTYPES)
-        self.n_features_in_ = X.shape[1]
+        X, y = validate_data(self, X=X, y=y, dtype=FLOAT_DTYPES, reset=True)
+        _check_n_features(self, X, reset=True)
 
         return self
 
@@ -89,8 +89,8 @@ class RandomAdder(TrainOnlyTransformerMixin, BaseEstimator):
         """
         rs = check_random_state(self.random_state)
         check_is_fitted(self, ["n_features_in_"])
-
-        X = check_array(X, estimator=self, dtype=FLOAT_DTYPES)
+        X = validate_data(self, X=X, dtype=FLOAT_DTYPES, reset=False)
+        _check_n_features(self, X, reset=False)
 
         return X + rs.normal(0, self.noise, size=X.shape)
 
@@ -104,3 +104,8 @@ class RandomAdder(TrainOnlyTransformerMixin, BaseEstimator):
 
     def _more_tags(self):
         return {"non_deterministic": True}
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.non_deterministic = True
+        return tags

--- a/sklego/preprocessing/repeatingbasis.py
+++ b/sklego/preprocessing/repeatingbasis.py
@@ -1,8 +1,8 @@
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.compose import ColumnTransformer
-from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
+from sklearn_compat.utils.validation import _check_n_features, validate_data
 
 
 class RepeatingBasisFunction(TransformerMixin, BaseEstimator):
@@ -163,7 +163,8 @@ class _RepeatingBasisFunction(TransformerMixin, BaseEstimator):
         self : _RepeatingBasisFunction
             The fitted transformer.
         """
-        X = check_array(X, estimator=self)
+        X = validate_data(self, X=X, ensure_2d=True, reset=True)
+        _check_n_features(self, X, reset=True)
 
         # find min and max for standardization if not given explicitly
         if self.input_range is None:
@@ -195,11 +196,9 @@ class _RepeatingBasisFunction(TransformerMixin, BaseEstimator):
         ValueError
             If X has more than one column, as this transformer only accepts one feature as input.
         """
-        X = check_array(X, estimator=self, ensure_2d=True)
         check_is_fitted(self, ["bases_", "width_"])
-        # This transformer only accepts one feature as input
-        if X.shape[1] != 1:
-            raise ValueError(f"X should have exactly one column, it has: {X.shape[1]}")
+        X = validate_data(self, X=X, ensure_2d=True, reset=False)
+        _check_n_features(self, X, reset=False)
 
         # MinMax Scale to 0-1
         X = (X - self.input_range[0]) / (self.input_range[1] - self.input_range[0])

--- a/sklego/preprocessing/repeatingbasis.py
+++ b/sklego/preprocessing/repeatingbasis.py
@@ -2,7 +2,8 @@ import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.compose import ColumnTransformer
 from sklearn.utils.validation import check_is_fitted
-from sklearn_compat.utils.validation import _check_n_features, validate_data
+
+from sklego._sklearn_compat import _check_n_features, check_array
 
 
 class RepeatingBasisFunction(TransformerMixin, BaseEstimator):
@@ -163,7 +164,7 @@ class _RepeatingBasisFunction(TransformerMixin, BaseEstimator):
         self : _RepeatingBasisFunction
             The fitted transformer.
         """
-        X = validate_data(self, X=X, ensure_2d=True, reset=True)
+        X = check_array(X, estimator=self, ensure_2d=True)
         _check_n_features(self, X, reset=True)
 
         # find min and max for standardization if not given explicitly
@@ -197,7 +198,7 @@ class _RepeatingBasisFunction(TransformerMixin, BaseEstimator):
             If X has more than one column, as this transformer only accepts one feature as input.
         """
         check_is_fitted(self, ["bases_", "width_"])
-        X = validate_data(self, X=X, ensure_2d=True, reset=False)
+        X = check_array(X, estimator=self, ensure_2d=True)
         _check_n_features(self, X, reset=False)
 
         # MinMax Scale to 0-1

--- a/tests/test_estimators/test_demographic_parity.py
+++ b/tests/test_estimators/test_demographic_parity.py
@@ -37,6 +37,7 @@ def test_sklearn_compatible_estimator(estimator, check):
         # the test
         "check_classifiers_train",
         "check_n_features_in",  # TODO: This should be fixable?!
+        "check_n_features_in_after_fitting",  # same problem as above, new check in 1.6
     }:
         pytest.skip()
 

--- a/tests/test_estimators/test_equal_opportunity.py
+++ b/tests/test_estimators/test_equal_opportunity.py
@@ -33,6 +33,7 @@ def test_sklearn_compatible_estimator(estimator, check):
         # the test
         "check_classifiers_train",
         "check_n_features_in",  # TODO: This should be fixable?!
+        "check_n_features_in_after_fitting",  # same problem as above, new check in 1.6
     }:
         pytest.skip()
     check(estimator)

--- a/tests/test_estimators/test_imbalanced_linear_regression.py
+++ b/tests/test_estimators/test_imbalanced_linear_regression.py
@@ -31,6 +31,10 @@ def _create_dataset(coefs, intercept, noise=0.0):
     ]
 )
 def test_sklearn_compatible_estimator(estimator, check):
+    if check.func.__name__ in {
+        "check_sample_weight_equivalence_on_dense_data",
+    }:
+        pytest.skip()
     check(estimator)
 
 

--- a/tests/test_estimators/test_quantile_regression.py
+++ b/tests/test_estimators/test_quantile_regression.py
@@ -33,6 +33,7 @@ def _create_dataset(coefs, intercept, noise=0.0):
 )
 def test_sklearn_compatible_estimator(estimator, check):
     if check.func.__name__ in {
+        "check_sample_weights_invariance",
         "check_sample_weight_equivalence_on_dense_data",
     }:
         pytest.skip()

--- a/tests/test_estimators/test_quantile_regression.py
+++ b/tests/test_estimators/test_quantile_regression.py
@@ -32,11 +32,9 @@ def _create_dataset(coefs, intercept, noise=0.0):
     ]
 )
 def test_sklearn_compatible_estimator(estimator, check):
-    if (
-        estimator.method != "SLSQP"
-        and check.func.__name__ == "check_sample_weights_invariance"
-        and getattr(check, "keywords", {}).get("kind") == "zeros"
-    ):
+    if check.func.__name__ in {
+        "check_sample_weight_equivalence_on_dense_data",
+    }:
         pytest.skip()
     check(estimator)
 

--- a/tests/test_meta/test_decay_estimator.py
+++ b/tests/test_meta/test_decay_estimator.py
@@ -18,6 +18,7 @@ from sklego.meta import DecayEstimator
 def test_sklearn_compatible_estimator(estimator, check):
     if check.func.__name__ in {
         "check_no_attributes_set_in_init",  # Setting **kwargs in init
+        "check_regressor_multioutput",  # incompatible between pre and post 1.6
     }:
         pytest.skip()
 

--- a/tests/test_meta/test_grouped_predictor.py
+++ b/tests/test_meta/test_grouped_predictor.py
@@ -33,6 +33,7 @@ def test_sklearn_compatible_estimator(estimator, check):
         "check_estimators_empty_data_messages",  # custom message
         "check_supervised_y_2d",  # TODO: Is it possible to support multioutput?
         "check_requires_y_none",
+        "check_n_features_in_after_fitting",  # custom check without validate_data
     }:
         pytest.skip()
 

--- a/tests/test_meta/test_grouped_transformer.py
+++ b/tests/test_meta/test_grouped_transformer.py
@@ -28,6 +28,7 @@ def test_sklearn_compatible_estimator(estimator, check):
         "check_estimators_empty_data_messages",  # custom message
         "check_estimators_pickle",  # Fails if input contains nan
         "check_fit1d",
+        "check_n_features_in_after_fitting",  # custom check without validate_data
     }:
         pytest.skip()
 

--- a/tests/test_meta/test_hierarchical_predictor.py
+++ b/tests/test_meta/test_hierarchical_predictor.py
@@ -32,6 +32,7 @@ def test_sklearn_compatible_estimator(estimator, check):
         "check_supervised_y_2d",  # TODO: Is it possible to support multioutput?
         "check_estimators_empty_data_messages",  # custom message
         "check_requires_y_none",
+        "check_n_features_in_after_fitting",  # custom check
     }:
         pytest.skip()
 

--- a/tests/test_meta/test_subjective_classifier.py
+++ b/tests/test_meta/test_subjective_classifier.py
@@ -141,6 +141,10 @@ def test_weighted_proba(weights, y_hats, expected_probas):
     ],
 )
 def test_predict_proba(mocker, evidence_type, expected_probas):
+    subjective_model = SubjectiveClassifier(
+        estimator=RandomForestClassifier(), prior={0: 0.8, 1: 0.2}, evidence=evidence_type
+    )
+
     def mock_confusion_matrix(y, y_pred):
         return np.array([[80, 20], [10, 90]])
 
@@ -151,11 +155,7 @@ def test_predict_proba(mocker, evidence_type, expected_probas):
         new_callable=mocker.PropertyMock,
         return_value=np.array(classes),
     )
-    mock_inner_estimator = mocker.MagicMock(RandomForestClassifier)
-
-    mock_inner_estimator.classes_ = np.array(classes)
-    subjective_model = SubjectiveClassifier(mock_inner_estimator, {0: 0.8, 1: 0.2}, evidence=evidence_type)
-    subjective_model.fit(np.zeros((10, 10)), np.zeros(10))
+    subjective_model.fit(np.zeros((10, 2)), np.zeros(10))
 
     subjective_model.estimator_.predict_proba = lambda X: np.array([[0.8, 0.2], [1, 0], [0.5, 0.5], [0.2, 0.8]])
     posterior_probabilities = subjective_model.predict_proba(np.zeros((4, 2)))

--- a/tests/test_meta/test_thresholder.py
+++ b/tests/test_meta/test_thresholder.py
@@ -12,6 +12,7 @@ from sklego.meta import Thresholder
 def test_sklearn_compatible_estimator(estimator, check):
     if check.func.__name__ in {
         "check_fit2d_1feature",  # custom message
+        "check_sample_weight_equivalence_on_dense_data",  # TODO: come back to this
     }:
         pytest.skip()
 

--- a/tests/test_meta/test_zero_inflated_regressor.py
+++ b/tests/test_meta/test_zero_inflated_regressor.py
@@ -64,9 +64,7 @@ def test_zero_inflated_with_sample_weights_example(classifier, regressor, perfor
     y = ((X[:, 0] > 0) & (X[:, 1] > 0)) * np.abs(X[:, 2] * X[:, 3] ** 2)  # many zeroes here, in about 75% of the cases.
 
     zir = ZeroInflatedRegressor(classifier=classifier, regressor=regressor)
-
-    zir_score = cross_val_score(zir, X, y, fit_params={"sample_weight": np.arange(len(y))}).mean()
-    # TODO: fit_params -> params in future versions
+    zir_score = cross_val_score(zir, X, y, params={"sample_weight": np.arange(len(y))}).mean()
 
     assert zir_score > performance
 

--- a/tests/test_preprocessing/test_columncapper.py
+++ b/tests/test_preprocessing/test_columncapper.py
@@ -15,11 +15,11 @@ def test_sklearn_compatible_estimator(estimator, check):
 def test_quantile_range():
     def expect_type_error(quantile_range):
         with pytest.raises(TypeError):
-            ColumnCapper(quantile_range)
+            ColumnCapper(quantile_range).fit([])
 
     def expect_value_error(quantile_range):
         with pytest.raises(ValueError):
-            ColumnCapper(quantile_range)
+            ColumnCapper(quantile_range).fit([])
 
     # Testing quantile_range type
     expect_type_error(quantile_range=1)
@@ -49,7 +49,7 @@ def test_interpolation():
 
     for interpolation in invalid_interpolations:
         with pytest.raises(ValueError):
-            ColumnCapper(interpolation=interpolation)
+            ColumnCapper(interpolation=interpolation).fit([])
 
 
 @pytest.fixture()


### PR DESCRIPTION
# Description

Overseeds #720 by using and adapting [sklearn-compat](https://github.com/sklearn-compat/sklearn-compat)

Tested on python 3.10 and 3.12 with scikit-learn 1.5 and 1.6: all tests are passing these local runs


## Tip for review

I tried to carefully commit each module at the time, hence the best way forward would be to review one commit at the time.

~~With a big disclaimer, at the end I realized that we `validate_data` was not gonna work in all situations, but an adaptation of `check_X_y` would, therefore I rolled back those entirely in another branch which was merged into this one~~

Edit: as suggested, using `validate_data` is the right way to go, and after some deeper dive, I was able to refactor the codebase using such function