### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description="A collection of lego bricks for scikit-learn pipelines"
 
 license = {file = "LICENSE"}
 readme = "readme.md"
-requires-python = ">=3.6"
+requires-python = ">=3.9"
 authors = [
     {name = "Vincent D. Warmerdam"},
     {name = "Matthijs Brouns"},
@@ -24,13 +24,11 @@ dependencies = [
     "pandas>=1.1.5",
     "scikit-learn>=1.0",
     "sklearn-compat>=0.1.3",
-    "importlib-metadata >= 1.0; python_version < '3.8'",
     "importlib-resources; python_version < '3.9'",
 ]
 
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
This PR addresses issue #734 by dropping Python 3.8 support from the project configuration.

### Changes

- Update minimum Python version from 3.6 to 3.9 in `pyproject.toml`
- Remove Python 3.8 from project classifiers
- Remove `importlib-metadata` conditional dependency (not needed for Python 3.9+)

This aligns with the current CI test matrix which only tests Python 3.9-3.13, and prepares for future narwhals versions that may drop Python 3.8 support.

Fixes #734

Generated with [Claude Code](https://claude.ai/code)