### PR TITLE
Fix the issue where the last fold fails to include the final sample

### DIFF
--- a/sklego/model_selection.py
+++ b/sklego/model_selection.py
@@ -204,9 +204,12 @@ class TimeGapSplit:
             X_train_df = X_index_df.filter(
                 nw.col("__date__") >= start_date, nw.col("__date__") < current_date + self.train_duration
             )
+            valid_end = current_date + self.train_duration + self.valid_duration + self.gap_duration
+            if valid_end >= date_max:
+                valid_end = valid_end + pd.Timedelta("1ns")
             X_valid_df = X_index_df.filter(
                 nw.col("__date__") >= current_date + self.train_duration + self.gap_duration,
-                nw.col("__date__") < current_date + self.train_duration + self.valid_duration + self.gap_duration,
+                nw.col("__date__") < valid_end,
             )
 
             current_date = current_date + time_shift


### PR DESCRIPTION
The validation split previously used a right-open interval:

`__date__ < valid_end`

When the final fold's `valid_end` was exactly equal to the maximum timestamp in the dataset, the last sample (`dt == max_dt`) was excluded from all folds.

This PR ensures that the final fold correctly includes the last sample by slightly extending the upper boundary when `valid_end >= date_max`, while preserving the non-overlapping property of intermediate folds.

This change:

* Fixes the edge case where the final sample is never included in any validation set.
* Maintains strict non-overlapping validation folds.
* Does not affect behavior for intermediate folds.

Before working on a large PR, please check with @FBruzzesi or @koaning to confirm that they agree with the direction of the PR. This discussion should take place in a [Github issue](https://github.com/koaning/scikit-lego/issues/new/choose) before working on the PR, unless it's a minor change like spelling in the docs. 

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [ ] My code follows the style guidelines (ruff)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (also to the readme.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added tests to check whether the new feature adheres to the sklearn convention
- [ ] New and existing unit tests pass locally with my changes

If you feel your PR is ready for a review, ping @FBruzzesi or @koaning.
