### PR TITLE
fix: Add `date_series` as `TimeGapSplit` parameter and deprecate `date_serie`

### DIFF
--- a/docs/_scripts/cross-validation.py
+++ b/docs/_scripts/cross-validation.py
@@ -54,7 +54,7 @@ with open(_static_path / "ts.md", "w") as f:
 
 # --8<-- [start:example-1]
 cv = TimeGapSplit(
-    date_serie=df["date"],
+    date_series=df["date"],
     train_duration=timedelta(days=10),
     valid_duration=timedelta(days=2),
     gap_duration=timedelta(days=1)
@@ -70,7 +70,7 @@ plt.clf()
 
 # --8<-- [start:example-2]
 cv = TimeGapSplit(
-    date_serie=df["date"],
+    date_series=df["date"],
     train_duration=timedelta(days=10),
     valid_duration=timedelta(days=5),
     gap_duration=timedelta(days=1)
@@ -85,7 +85,7 @@ plt.clf()
 
 # --8<-- [start:example-3]
 cv = TimeGapSplit(
-    date_serie=df["date"],
+    date_series=df["date"],
     train_duration=timedelta(days=10),
     valid_duration=timedelta(days=2),
     gap_duration=timedelta(days=1),
@@ -101,7 +101,7 @@ plt.clf()
 
 # --8<-- [start:example-4]
 cv = TimeGapSplit(
-    date_serie=df["date"],
+    date_series=df["date"],
     train_duration=None,
     valid_duration=timedelta(days=3),
     gap_duration=timedelta(days=2),
@@ -117,7 +117,7 @@ plt.clf()
 
 # --8<-- [start:example-5]
 cv = TimeGapSplit(
-    date_serie=df["date"],
+    date_series=df["date"],
     train_duration=timedelta(days=10),
     valid_duration=timedelta(days=2),
     gap_duration=timedelta(days=1),

--- a/sklego/model_selection.py
+++ b/sklego/model_selection.py
@@ -50,8 +50,6 @@ class TimeGapSplit:
         Series with the date, that should have all the indices of X used in the split() method.
         If the Series is not pandas-like (for example, if it's a Polars Series, which does not have
         an index) then it must the same length as the `X` and `y` objects passed to `split`.
-    date_serie : Series | None, default=None
-        Backward-compatible alias for `date_series`.
     valid_duration : datetime.timedelta
         Retraining period.
     stride_duration : datetime.timedelta | None
@@ -69,6 +67,8 @@ class TimeGapSplit:
 
         - `"rolling"` window has fixed size and is shifted entirely.
         - `"expanding"` left side of window is fixed, right border increases each fold.
+    date_serie : Series | None, default=None
+        Backward-compatible alias for `date_series`.
 
     Notes
     -----
@@ -88,26 +88,34 @@ class TimeGapSplit:
 
     def __init__(
         self,
-        date_serie=None,
+        date_series=None,
         valid_duration=None,
         stride_duration=None,
         train_duration=None,
         gap_duration=timedelta(0),
         n_splits=None,
         window="rolling",
-        date_series=None,
+        date_serie=None,
     ):
         if valid_duration is None:
             raise ValueError("`valid_duration` has to be defined")
 
-        if (date_serie is None) and (date_series is None):
-            raise ValueError("Either `date_series` or `date_serie` has to be defined")
-
-        if (date_serie is not None) and (date_series is not None):
-            raise ValueError("Only one of `date_series` and `date_serie` can be provided")
-
-        if date_series is not None:
-            date_serie = date_series
+        match (date_series, date_serie):
+            case (None, None):
+                msg = "`date_series` cannot be None"
+                raise ValueError(msg)
+            case (value, None):
+                self.date_series = nw.from_native(value, series_only=True).alias("__date__")
+            case (None, value):
+                msg = (
+                    "Please use `date_series` instead of `date_serie`, "
+                    "`date_serie` will be deprecated in future versions"
+                )
+                warn(msg, DeprecationWarning)
+                self.date_series = nw.from_native(value, series_only=True).alias("__date__")
+            case (_, _):
+                msg = "Cannot provide both `date_series` and `date_serie`"
+                raise ValueError(msg)
 
         # If stride length is not defined, set it equal to the length validation set
         if stride_duration is None:
@@ -126,7 +134,6 @@ class TimeGapSplit:
         if (train_duration is not None) and (train_duration <= stride_duration):
             raise ValueError("stride_duration is longer than train_duration, it should be shorter.")
 
-        self.date_series = nw.from_native(date_serie, series_only=True).alias("__date__")
         self.date_serie = self.date_series
         self.train_duration = train_duration
         self.valid_duration = valid_duration

--- a/sklego/model_selection.py
+++ b/sklego/model_selection.py
@@ -46,10 +46,12 @@ class TimeGapSplit:
 
     Parameters
     ----------
-    date_serie : Series
+    date_series : Series
         Series with the date, that should have all the indices of X used in the split() method.
         If the Series is not pandas-like (for example, if it's a Polars Series, which does not have
         an index) then it must the same length as the `X` and `y` objects passed to `split`.
+    date_serie : Series | None, default=None
+        Backward-compatible alias for `date_series`.
     valid_duration : datetime.timedelta
         Retraining period.
     stride_duration : datetime.timedelta | None
@@ -86,14 +88,27 @@ class TimeGapSplit:
 
     def __init__(
         self,
-        date_serie,
-        valid_duration,
+        date_serie=None,
+        valid_duration=None,
         stride_duration=None,
         train_duration=None,
         gap_duration=timedelta(0),
         n_splits=None,
         window="rolling",
+        date_series=None,
     ):
+        if valid_duration is None:
+            raise ValueError("`valid_duration` has to be defined")
+
+        if (date_serie is None) and (date_series is None):
+            raise ValueError("Either `date_series` or `date_serie` has to be defined")
+
+        if (date_serie is not None) and (date_series is not None):
+            raise ValueError("Only one of `date_series` and `date_serie` can be provided")
+
+        if date_series is not None:
+            date_serie = date_series
+
         # If stride length is not defined, set it equal to the length validation set
         if stride_duration is None:
             stride_duration = valid_duration
@@ -111,7 +126,8 @@ class TimeGapSplit:
         if (train_duration is not None) and (train_duration <= stride_duration):
             raise ValueError("stride_duration is longer than train_duration, it should be shorter.")
 
-        self.date_serie = nw.from_native(date_serie, series_only=True).alias("__date__")
+        self.date_series = nw.from_native(date_serie, series_only=True).alias("__date__")
+        self.date_serie = self.date_series
         self.train_duration = train_duration
         self.valid_duration = valid_duration
         self.gap_duration = gap_duration
@@ -120,7 +136,7 @@ class TimeGapSplit:
         self.window = window
 
     def _join_date_and_x(self, X):
-        """Creates a DataFrame indexed by the pandas index (the same as `date_serie`) with date column joined with that
+        """Creates a DataFrame indexed by the pandas index (the same as `date_series`) with date column joined with that
         index and with the 'numpy index' column (i.e. just a range) that is required for the output and the rest of
         sklearn.
 
@@ -132,7 +148,7 @@ class TimeGapSplit:
         X : DataFrame
             Dataframe with the data to split
         """
-        X_index_df = nw.maybe_align_index(self.date_serie, X).to_frame().with_row_index("np_index")
+        X_index_df = nw.maybe_align_index(self.date_series, X).to_frame().with_row_index("np_index")
 
         return X_index_df
 
@@ -160,7 +176,7 @@ class TimeGapSplit:
 
         if len(X) != len(X_index_df):
             raise AssertionError(
-                "X and X_index_df are not the same length, there must be some index missing in 'self.date_serie'"
+                "X and X_index_df are not the same length, there must be some index missing in 'self.date_series'"
             )
 
         date_min = X_index_df["__date__"].min()

--- a/tests/test_model_selection/test_timegapsplit.py
+++ b/tests/test_model_selection/test_timegapsplit.py
@@ -55,7 +55,7 @@ y_train = train["y"]
 )
 def test_timegapsplit(stride_duration, expected):
     cv = TimeGapSplit(
-        date_serie=df["date"],
+        date_series=df["date"],
         train_duration=timedelta(days=5),
         valid_duration=timedelta(days=3),
         stride_duration=timedelta(days=stride_duration),
@@ -67,11 +67,11 @@ def test_timegapsplit(stride_duration, expected):
         np.testing.assert_array_equal(result_indices[1], expected_indices[1])
 
     # Polars doesn't have an index, so this class behaves a bit differenly for
-    # index-less objects. We need to first ensure that `date_serie`, `X_train`,
+    # index-less objects. We need to first ensure that `date_series`, `X_train`,
     # and `y_train` all have the same length.
-    date_serie = df["date"].loc[X_train.index]
+    date_series = df["date"].loc[X_train.index]
     cv = TimeGapSplit(
-        date_serie=pl.from_pandas(date_serie),
+        date_series=pl.from_pandas(date_series),
         train_duration=timedelta(days=5),
         valid_duration=timedelta(days=3),
         stride_duration=timedelta(days=stride_duration),
@@ -87,7 +87,7 @@ def test_timegapsplit(stride_duration, expected):
 def test_timegapsplit_too_big_gap():
     try:
         TimeGapSplit(
-            date_serie=df["date"],
+            date_series=df["date"],
             train_duration=timedelta(days=5),
             valid_duration=timedelta(days=3),
             gap_duration=timedelta(days=5),
@@ -103,12 +103,16 @@ def test_timegapsplit_accepts_date_series_alias():
         valid_duration=timedelta(days=3),
         gap_duration=timedelta(days=0),
     )
-    cv_with_legacy_name = TimeGapSplit(
-        date_serie=df["date"],
-        train_duration=timedelta(days=5),
-        valid_duration=timedelta(days=3),
-        gap_duration=timedelta(days=0),
-    )
+    with pytest.warns(
+        DeprecationWarning,
+        match="Please use `date_series` instead of `date_serie`, `date_serie` will be deprecated in future versions",
+    ):
+        cv_with_legacy_name = TimeGapSplit(
+            date_serie=df["date"],
+            train_duration=timedelta(days=5),
+            valid_duration=timedelta(days=3),
+            gap_duration=timedelta(days=0),
+        )
 
     alias_splits = list(cv_with_alias.split(X_train, y_train))
     legacy_splits = list(cv_with_legacy_name.split(X_train, y_train))
@@ -119,8 +123,21 @@ def test_timegapsplit_accepts_date_series_alias():
         np.testing.assert_array_equal(alias_split[1], legacy_split[1])
 
 
+def test_timegapsplit_warns_on_date_serie_legacy_alias():
+    with pytest.warns(
+        DeprecationWarning,
+        match="Please use `date_series` instead of `date_serie`, `date_serie` will be deprecated in future versions",
+    ):
+        _ = TimeGapSplit(
+            date_serie=df["date"],
+            train_duration=timedelta(days=5),
+            valid_duration=timedelta(days=3),
+            gap_duration=timedelta(days=0),
+        )
+
+
 def test_timegapsplit_rejects_both_date_series_and_date_serie():
-    with pytest.raises(ValueError, match="Only one of `date_series` and `date_serie` can be provided"):
+    with pytest.raises(ValueError, match="Cannot provide both `date_series` and `date_serie`"):
         _ = TimeGapSplit(
             date_series=df["date"],
             date_serie=df["date"],
@@ -130,9 +147,18 @@ def test_timegapsplit_rejects_both_date_series_and_date_serie():
         )
 
 
+def test_timegapsplit_rejects_missing_date_series_argument():
+    with pytest.raises(ValueError, match="`date_series` cannot be None"):
+        _ = TimeGapSplit(
+            train_duration=timedelta(days=5),
+            valid_duration=timedelta(days=3),
+            gap_duration=timedelta(days=0),
+        )
+
+
 def test_timegapsplit_using_splits():
     cv = TimeGapSplit(
-        date_serie=df["date"],
+        date_series=df["date"],
         train_duration=timedelta(days=5),
         valid_duration=timedelta(days=3),
         gap_duration=timedelta(days=1),
@@ -143,7 +169,7 @@ def test_timegapsplit_using_splits():
 
 def test_timegapsplit_too_many_splits():
     cv = TimeGapSplit(
-        date_serie=df["date"],
+        date_series=df["date"],
         train_duration=timedelta(days=5),
         valid_duration=timedelta(days=3),
         gap_duration=timedelta(days=1),
@@ -156,7 +182,7 @@ def test_timegapsplit_too_many_splits():
 def test_timegapsplit_train_or_nsplit():
     with pytest.raises(ValueError):
         _ = TimeGapSplit(
-            date_serie=df["date"],
+            date_series=df["date"],
             train_duration=None,
             valid_duration=timedelta(days=3),
             gap_duration=timedelta(days=5),
@@ -166,7 +192,7 @@ def test_timegapsplit_train_or_nsplit():
 
 def test_timegapsplit_without_train_duration():
     cv = TimeGapSplit(
-        date_serie=df["date"],
+        date_series=df["date"],
         train_duration=None,
         valid_duration=timedelta(days=3),
         gap_duration=timedelta(days=5),
@@ -181,7 +207,7 @@ def test_timegapsplit_without_train_duration():
 def test_timegapsplit_with_a_gap():
     gap_duration = timedelta(days=2)
     cv_gap = TimeGapSplit(
-        date_serie=df["date"],
+        date_series=df["date"],
         train_duration=timedelta(days=5),
         valid_duration=timedelta(days=3),
         gap_duration=gap_duration,
@@ -200,7 +226,7 @@ def test_timegapsplit_with_a_gap():
 def test_timegapsplit_stride_is_zero():
     with pytest.raises(ValueError):
         _ = TimeGapSplit(
-            date_serie=df["date"],
+            date_series=df["date"],
             train_duration=timedelta(days=5),
             stride_duration=timedelta(days=0),
             valid_duration=timedelta(days=3),
@@ -212,7 +238,7 @@ def test_timegapsplit_stride_is_zero():
 def test_timegapsplit_stride_longer_than_train():
     with pytest.raises(ValueError):
         _ = TimeGapSplit(
-            date_serie=df["date"],
+            date_series=df["date"],
             train_duration=timedelta(days=5),
             stride_duration=timedelta(days=6),
             valid_duration=timedelta(days=3),
@@ -224,7 +250,7 @@ def test_timegapsplit_stride_longer_than_train():
 def test_timegapsplit_with_stride():
     stride_duration = timedelta(days=2)
     cv_gap = TimeGapSplit(
-        date_serie=df["date"],
+        date_series=df["date"],
         train_duration=timedelta(days=5),
         stride_duration=stride_duration,
         valid_duration=timedelta(days=3),
@@ -243,7 +269,7 @@ def test_timegapsplit_with_stride():
 
 def test_timegapsplit_with_gridsearch():
     cv = TimeGapSplit(
-        date_serie=df["date"],
+        date_series=df["date"],
         train_duration=timedelta(days=5),
         valid_duration=timedelta(days=3),
         gap_duration=timedelta(days=0),
@@ -262,7 +288,7 @@ def test_timegapsplit_with_gridsearch():
 
 def test_timegapsplit_summary():
     cv = TimeGapSplit(
-        date_serie=df["date"],
+        date_series=df["date"],
         train_duration=timedelta(days=5),
         valid_duration=timedelta(days=3),
         gap_duration=timedelta(days=0),
@@ -336,11 +362,11 @@ def test_timegapsplit_summary():
     pandas_assert_frame_equal(summary, expected)
 
     # Polars doesn't have an index, so this class behaves a bit differently for
-    # index-less objects. We need to ensure that `date_serie` and `X_train` have
+    # index-less objects. We need to ensure that `date_series` and `X_train` have
     # the same length.
-    date_serie = df["date"].loc[X_train.index]
+    date_series = df["date"].loc[X_train.index]
     cv = TimeGapSplit(
-        date_serie=pl.from_pandas(date_serie),
+        date_series=pl.from_pandas(date_series),
         train_duration=timedelta(days=5),
         valid_duration=timedelta(days=3),
         gap_duration=timedelta(days=0),

--- a/tests/test_model_selection/test_timegapsplit.py
+++ b/tests/test_model_selection/test_timegapsplit.py
@@ -96,6 +96,40 @@ def test_timegapsplit_too_big_gap():
         print("Successfully failed")  # noqa: T201
 
 
+def test_timegapsplit_accepts_date_series_alias():
+    cv_with_alias = TimeGapSplit(
+        date_series=df["date"],
+        train_duration=timedelta(days=5),
+        valid_duration=timedelta(days=3),
+        gap_duration=timedelta(days=0),
+    )
+    cv_with_legacy_name = TimeGapSplit(
+        date_serie=df["date"],
+        train_duration=timedelta(days=5),
+        valid_duration=timedelta(days=3),
+        gap_duration=timedelta(days=0),
+    )
+
+    alias_splits = list(cv_with_alias.split(X_train, y_train))
+    legacy_splits = list(cv_with_legacy_name.split(X_train, y_train))
+
+    assert len(alias_splits) == len(legacy_splits)
+    for alias_split, legacy_split in zip(alias_splits, legacy_splits):
+        np.testing.assert_array_equal(alias_split[0], legacy_split[0])
+        np.testing.assert_array_equal(alias_split[1], legacy_split[1])
+
+
+def test_timegapsplit_rejects_both_date_series_and_date_serie():
+    with pytest.raises(ValueError, match="Only one of `date_series` and `date_serie` can be provided"):
+        _ = TimeGapSplit(
+            date_series=df["date"],
+            date_serie=df["date"],
+            train_duration=timedelta(days=5),
+            valid_duration=timedelta(days=3),
+            gap_duration=timedelta(days=0),
+        )
+
+
 def test_timegapsplit_using_splits():
     cv = TimeGapSplit(
         date_serie=df["date"],


### PR DESCRIPTION
## Description:

Issue #761 reported a typo in the `TimeGapSplit` constructor argument name, where `date_serie` was used instead of `date_series`.

This PR adds a backward compatible fix:

- Supports the correct argument name `date_series`
- Keeps support for the legacy name `date_serie`
- Validates that exactly one of `date_series` or `date_serie` is provided
- Keeps internal compatibility by aliasing `date_serie` to `date_series`
- Updates `TimeGapSplit` docs examples to use `date_series`

It also adds regression tests that cover:

- `date_series` works correctly
- Passing both `date_series` and `date_serie` raises a clear `ValueError`

Closes #761.

## Validation:

- `ruff check sklego/model_selection.py tests/test_model_selection/test_timegapsplit.py`
- `pytest -q tests/test_model_selection/test_timegapsplit.py`
- `pytest -q`

Note: `pytest -q` reports one unrelated pre-existing failure in `tests/test_meta/test_grouped_predictor.py::test_custom_shrinkage`. (See #785 )

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines (ruff)
- [x] I have commented my code, particularly in hard to understand areas
- [ ] I have made corresponding changes to the documentation (also to the readme.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added tests to check whether the new feature adheres to the sklearn convention
- [x] New and existing unit tests pass locally with my changes

#### The validation screenshots of the tests run, locally on WSL:

<img width="1423" height="213" alt="image" src="https://github.com/user-attachments/assets/be985724-85db-48e5-8b60-94e2fd937832" />

<img width="1695" height="1130" alt="Screenshot 2026-04-16 223559" src="https://github.com/user-attachments/assets/229ce889-dd0d-4eb7-b95b-53ac98df42fa" />
