### PR TITLE
deps: Bump jupyterlab, nbconvert, notebook due to sec vulnerabilities

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,7 @@ repos:
         args: [--fix, sklego, tests]
     -   id: ruff-format # Run the formatter.
         args: [sklego, tests]
+-   repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.11.8
+    hooks:
+    -   id: uv-lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,8 @@ utils = [
     "requests>=2.33.0",  # jupyter dep, vulnerability found in 2.32.5, fixed in 2.33.0
     "tornado>=6.5.5",  # jupyter dep, 2 vulnerabilities in 6.5.2, fixed in 6.5.5
     "notebook>=7.5.6",  # jupyter dep, vulerability in 7.4.7, fixed in 7.5.6
+    "jupyter-server>=2.18.0",  # jupyter dep, 4 vulerabilities in 2.17.0, fixed in 2.18.0
+    "mistune>=3.2.1",  # jupyter dep, vulerability in 3.1.4, fixed in 3.2.1
 ]
 
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,13 +76,14 @@ test-all = [
 utils = [
     "matplotlib>=3.0.2",
     "jupyter>=1.0.0",
-    "jupyterlab>=0.35.4",
+    "jupyterlab>=4.5.7",  # vulnerability found in 4.4.9, fixed in 4.5.7
     "fonttools>=4.60.2",  # matplotlib dep, vulnerability found in 4.60.1, fixed in 4.60.2
     "pillow>=12.2.0",  # matplotlib dep, vulnerability found in 11.3.0, fixed in 12.2.0
     "pygments>=2.20.0",   # jupyter dep, vulnerability found in 2.19.0, fixed in 2.20.0
     "nbconvert>=7.17.1",  # jupyter dep, 2 vulnerabilities found in 7.17.0, fixed in 7.17.1
     "requests>=2.33.0",  # jupyter dep, vulnerability found in 2.32.5, fixed in 2.33.0
     "tornado>=6.5.5",  # jupyter dep, 2 vulnerabilities in 6.5.2, fixed in 6.5.5
+    "notebook>=7.5.6",  # jupyter dep, vulerability in 7.4.7, fixed in 7.5.6
 ]
 
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ utils = [
     "fonttools>=4.60.2",  # matplotlib dep, vulnerability found in 4.60.1, fixed in 4.60.2
     "pillow>=12.2.0",  # matplotlib dep, vulnerability found in 11.3.0, fixed in 12.2.0
     "pygments>=2.20.0",   # jupyter dep, vulnerability found in 2.19.0, fixed in 2.20.0
-    "nbconvert>=7.17.0",  # jupyter dep, vulnerability found in 7.16.6, fixed in 7.17.0
+    "nbconvert>=7.17.1",  # jupyter dep, 2 vulnerabilities found in 7.17.0, fixed in 7.17.1
     "requests>=2.33.0",  # jupyter dep, vulnerability found in 2.32.5, fixed in 2.33.0
     "tornado>=6.5.5",  # jupyter dep, 2 vulnerabilities in 6.5.2, fixed in 6.5.5
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1916,7 +1916,7 @@ wheels = [
 
 [[package]]
 name = "nbconvert"
-version = "7.17.0"
+version = "7.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1934,9 +1934,9 @@ dependencies = [
     { name = "pygments" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/47/81f886b699450d0569f7bc551df2b1673d18df7ff25cc0c21ca36ed8a5ff/nbconvert-7.17.0.tar.gz", hash = "sha256:1b2696f1b5be12309f6c7d707c24af604b87dfaf6d950794c7b07acab96dda78", size = 862855, upload-time = "2026-01-29T16:37:48.478Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/b1/708e53fe2e429c103c6e6e159106bcf0357ac41aa4c28772bd8402339051/nbconvert-7.17.1.tar.gz", hash = "sha256:34d0d0a7e73ce3cbab6c5aae8f4f468797280b01fd8bd2ca746da8569eddd7d2", size = 865311, upload-time = "2026-04-08T00:44:14.914Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/4b/8d5f796a792f8a25f6925a96032f098789f448571eb92011df1ae59e8ea8/nbconvert-7.17.0-py3-none-any.whl", hash = "sha256:4f99a63b337b9a23504347afdab24a11faa7d86b405e5c8f9881cd313336d518", size = 261510, upload-time = "2026-01-29T16:37:46.322Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/bb0a9d5f46819c821dc1f004aa2cc29b1d91453297dbf5ff20470f00f193/nbconvert-7.17.1-py3-none-any.whl", hash = "sha256:aa85c087b435e7bf1ffd03319f658e285f2b89eccab33bc1ba7025495ab3e7c8", size = 261927, upload-time = "2026-04-08T00:44:12.845Z" },
 ]
 
 [[package]]
@@ -3205,7 +3205,7 @@ requires-dist = [
     { name = "mkdocstrings-python", marker = "extra == 'docs'", specifier = ">=1.7.3" },
     { name = "narwhals", specifier = ">=1.5.0" },
     { name = "narwhals", extras = ["polars", "pyarrow"], marker = "extra == 'test'" },
-    { name = "nbconvert", marker = "extra == 'utils'", specifier = ">=7.17.0" },
+    { name = "nbconvert", marker = "extra == 'utils'", specifier = ">=7.17.1" },
     { name = "numpy", marker = "extra == 'cvxpy'", specifier = "<2.0" },
     { name = "numpy", marker = "extra == 'umap'", specifier = "<2.0" },
     { name = "osqp", marker = "extra == 'cvxpy'" },

--- a/uv.lock
+++ b/uv.lock
@@ -1362,7 +1362,7 @@ wheels = [
 
 [[package]]
 name = "jupyterlab"
-version = "4.4.9"
+version = "4.5.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-lru" },
@@ -1380,9 +1380,9 @@ dependencies = [
     { name = "tornado" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/b2/7dad2d0049a904d17c070226a4f78f81905f93bfe09503722d210ccf9335/jupyterlab-4.4.9.tar.gz", hash = "sha256:ea55aca8269909016d5fde2dc09b97128bc931230183fe7e2920ede5154ad9c2", size = 22966654, upload-time = "2025-09-26T17:28:20.158Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/22/8440ec827762146e7cdecf04335bd348795899d29dc6ae82238707353a2c/jupyterlab-4.5.7.tar.gz", hash = "sha256:55a9822c4754da305f41e113452c68383e214dcf96de760146af89ce5d5117b0", size = 23992763, upload-time = "2026-04-29T16:43:51.328Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/fd/ac0979ebd1b1975c266c99b96930b0a66609c3f6e5d76979ca6eb3073896/jupyterlab-4.4.9-py3-none-any.whl", hash = "sha256:394c902827350c017430a8370b9f40c03c098773084bc53930145c146d3d2cb2", size = 12292552, upload-time = "2025-09-26T17:28:15.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/aa/537b8f7d80e799af19af35fb3ddfc970b951088a13c57dd9387dcfbb7f61/jupyterlab-4.5.7-py3-none-any.whl", hash = "sha256:fba4cb0e2c44a52859669d8c98b45de029d5e515f8407bf8534d2a8fc5f0964d", size = 12450123, upload-time = "2026-04-29T16:43:46.639Z" },
 ]
 
 [[package]]
@@ -1396,7 +1396,7 @@ wheels = [
 
 [[package]]
 name = "jupyterlab-server"
-version = "2.27.3"
+version = "2.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -1407,9 +1407,9 @@ dependencies = [
     { name = "packaging" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/c9/a883ce65eb27905ce77ace410d83587c82ea64dc85a48d1f7ed52bcfa68d/jupyterlab_server-2.27.3.tar.gz", hash = "sha256:eb36caca59e74471988f0ae25c77945610b887f777255aa21f8065def9e51ed4", size = 76173, upload-time = "2024-07-16T17:02:04.149Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", hash = "sha256:35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c", size = 76996, upload-time = "2025-10-22T13:59:18.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/09/2032e7d15c544a0e3cd831c51d77a8ca57f7555b2e1b2922142eddb02a84/jupyterlab_server-2.27.3-py3-none-any.whl", hash = "sha256:e697488f66c3db49df675158a77b3b017520d772c6e1548c7d9bcc5df7944ee4", size = 59700, upload-time = "2024-07-16T17:02:01.115Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/07/a000fe835f76b7e1143242ab1122e6362ef1c03f23f83a045c38859c2ae0/jupyterlab_server-2.28.0-py3-none-any.whl", hash = "sha256:e4355b148fdcf34d312bbbc80f22467d6d20460e8b8736bf235577dd18506968", size = 59830, upload-time = "2025-10-22T13:59:16.767Z" },
 ]
 
 [[package]]
@@ -1974,7 +1974,7 @@ wheels = [
 
 [[package]]
 name = "notebook"
-version = "7.4.7"
+version = "7.5.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jupyter-server" },
@@ -1983,9 +1983,9 @@ dependencies = [
     { name = "notebook-shim" },
     { name = "tornado" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/09/f6f64ba156842ef68d3ea763fa171a2f7e7224f200a15dd4af5b83c34756/notebook-7.4.7.tar.gz", hash = "sha256:3f0a04027dfcee8a876de48fba13ab77ec8c12f72f848a222ed7f5081b9e342a", size = 13937702, upload-time = "2025-09-27T08:00:22.536Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/c2/cf59bd2e6f2c8b976b52477e3e53bf6f97bc714ed046a51821afb428eaee/notebook-7.5.6.tar.gz", hash = "sha256:621174aade80108f0020b0f00738000b215f75fa3cd90771ad7aa0f24536a4e1", size = 14170814, upload-time = "2026-04-30T11:46:26.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/d7/06d13087e20388926e7423d2489e728d2e59f2453039cdb0574a7c070e76/notebook-7.4.7-py3-none-any.whl", hash = "sha256:362b7c95527f7dd3c4c84d410b782872fd9c734fb2524c11dd92758527b6eda6", size = 14342894, upload-time = "2025-09-27T08:00:18.496Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d6/1fd0646b9bbd9efbb0b8ae21b2325fbef515769a5621c03e31d8eb8da587/notebook-7.5.6-py3-none-any.whl", hash = "sha256:4dde3f8fb55fa8fb7946d58c6e869ce9baf46d00fc070664f62604569d0faca0", size = 14581730, upload-time = "2026-04-30T11:46:22.342Z" },
 ]
 
 [[package]]
@@ -3182,6 +3182,7 @@ utils = [
     { name = "jupyterlab" },
     { name = "matplotlib" },
     { name = "nbconvert" },
+    { name = "notebook" },
     { name = "pillow" },
     { name = "pygments" },
     { name = "requests" },
@@ -3195,7 +3196,7 @@ requires-dist = [
     { name = "fonttools", marker = "extra == 'utils'", specifier = ">=4.60.2" },
     { name = "formulaic", marker = "extra == 'formulaic'", specifier = ">=0.6.0" },
     { name = "jupyter", marker = "extra == 'utils'", specifier = ">=1.0.0" },
-    { name = "jupyterlab", marker = "extra == 'utils'", specifier = ">=0.35.4" },
+    { name = "jupyterlab", marker = "extra == 'utils'", specifier = ">=4.5.7" },
     { name = "matplotlib", marker = "extra == 'utils'", specifier = ">=3.0.2" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.3,<2.0.0" },
     { name = "mkdocs-autorefs", marker = "extra == 'docs'", specifier = ">=0.5.0" },
@@ -3206,6 +3207,7 @@ requires-dist = [
     { name = "narwhals", specifier = ">=1.5.0" },
     { name = "narwhals", extras = ["polars", "pyarrow"], marker = "extra == 'test'" },
     { name = "nbconvert", marker = "extra == 'utils'", specifier = ">=7.17.1" },
+    { name = "notebook", marker = "extra == 'utils'", specifier = ">=7.5.6" },
     { name = "numpy", marker = "extra == 'cvxpy'", specifier = "<2.0" },
     { name = "numpy", marker = "extra == 'umap'", specifier = "<2.0" },
     { name = "osqp", marker = "extra == 'cvxpy'" },

--- a/uv.lock
+++ b/uv.lock
@@ -1319,7 +1319,7 @@ wheels = [
 
 [[package]]
 name = "jupyter-server"
-version = "2.17.0"
+version = "2.18.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1342,9 +1342,9 @@ dependencies = [
     { name = "traitlets" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/ac/e040ec363d7b6b1f11304cc9f209dac4517ece5d5e01821366b924a64a50/jupyter_server-2.17.0.tar.gz", hash = "sha256:c38ea898566964c888b4772ae1ed58eca84592e88251d2cfc4d171f81f7e99d5", size = 731949, upload-time = "2025-08-21T14:42:54.042Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/15/1eacb0fcb79ef86e8a0a79a708e6ad7435f6f223097dd29a4ce861fabc44/jupyter_server-2.18.2.tar.gz", hash = "sha256:06b4f40d8a7a00bb39d5216859c81374a0e7cfefe6d8a5a7facc5a5c37c679a7", size = 753177, upload-time = "2026-05-06T07:04:36.274Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/80/a24767e6ca280f5a49525d987bf3e4d7552bf67c8be07e8ccf20271f8568/jupyter_server-2.17.0-py3-none-any.whl", hash = "sha256:e8cb9c7db4251f51ed307e329b81b72ccf2056ff82d50524debde1ee1870e13f", size = 388221, upload-time = "2025-08-21T14:42:52.034Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/50/ecf4f70d65bdb7519b28a33d1b2fee8a4b4ba1ae1a92f15d97e877c5de21/jupyter_server-2.18.2-py3-none-any.whl", hash = "sha256:fa5e46539ded65791838035a2b6001f13e54d5f64b8b3752eb1e91fdd641a5b8", size = 391907, upload-time = "2026-05-06T07:04:34.014Z" },
 ]
 
 [[package]]
@@ -1757,14 +1757,14 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.1.4"
+version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/02/a7fb8b21d4d55ac93cdcde9d3638da5dd0ebdd3a4fed76c7725e10b81cbe/mistune-3.1.4.tar.gz", hash = "sha256:b5a7f801d389f724ec702840c11d8fc48f2b33519102fc7ee739e8177b672164", size = 94588, upload-time = "2025-08-29T07:20:43.594Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/f0/8282d9641415e9e33df173516226b404d367a0fc55e1a60424a152913abc/mistune-3.1.4-py3-none-any.whl", hash = "sha256:93691da911e5d9d2e23bc54472892aff676df27a75274962ff9edc210364266d", size = 53481, upload-time = "2025-08-29T07:20:42.218Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
 ]
 
 [[package]]
@@ -3179,8 +3179,10 @@ umap = [
 utils = [
     { name = "fonttools" },
     { name = "jupyter" },
+    { name = "jupyter-server" },
     { name = "jupyterlab" },
     { name = "matplotlib" },
+    { name = "mistune" },
     { name = "nbconvert" },
     { name = "notebook" },
     { name = "pillow" },
@@ -3196,8 +3198,10 @@ requires-dist = [
     { name = "fonttools", marker = "extra == 'utils'", specifier = ">=4.60.2" },
     { name = "formulaic", marker = "extra == 'formulaic'", specifier = ">=0.6.0" },
     { name = "jupyter", marker = "extra == 'utils'", specifier = ">=1.0.0" },
+    { name = "jupyter-server", marker = "extra == 'utils'", specifier = ">=2.18.0" },
     { name = "jupyterlab", marker = "extra == 'utils'", specifier = ">=4.5.7" },
     { name = "matplotlib", marker = "extra == 'utils'", specifier = ">=3.0.2" },
+    { name = "mistune", marker = "extra == 'utils'", specifier = ">=3.2.1" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.3,<2.0.0" },
     { name = "mkdocs-autorefs", marker = "extra == 'docs'", specifier = ">=0.5.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.4.5" },


### PR DESCRIPTION
 # Description

As per title, bump dependencies due to recent security vulnerabilities

Closes #787, #788, #789, #792, #793

Additionally adds uv-lock pre-commit hook to lower effort to remember of sync-ing

