### PR TITLE
compare shrinkage predictions with approx not exact equality

### DIFF
--- a/tests/test_meta/test_grouped_predictor.py
+++ b/tests/test_meta/test_grouped_predictor.py
@@ -367,7 +367,7 @@ def test_custom_shrinkage(shrinkage_data):
         np.array([means["Earth"], means["BE"], means["Brussels"]]) @ shrinkage_factors,
     ]
 
-    assert expected_prediction == shrink_est.predict(X).tolist()
+    assert shrink_est.predict(X).tolist() == pytest.approx(expected_prediction)
 
 
 def test_custom_shrinkage_wrong_return_type(shrinkage_data):


### PR DESCRIPTION
Fixes #785.

`test_custom_shrinkage` asserted `expected_prediction == shrink_est.predict(X).tolist()` — exact float equality, which fails at machine precision on some platforms (the reporter saw `1.833333333333333 != 1.8333333333333333` on a clean `main`).

Switched to `pytest.approx`. Confirmed the reporter's exact diff passes under approx while still failing under `==`.