### PR TITLE
Clarify equal opportunity warning message

### DIFF
--- a/sklego/metrics.py
+++ b/sklego/metrics.py
@@ -166,14 +166,16 @@ def equal_opportunity_score(sensitive_column, positive_target=1):
         # fair so we return 0
         if len(y_given_z1_y1) == 0:
             warn(
-                f"No samples with y_hat == {positive_target} for {sensitive_column} == 1, returning 0",
+                f"No samples with y_true == {positive_target} and y_hat == {positive_target} "
+                f"for {sensitive_column} == 1, returning 0",
                 RuntimeWarning,
             )
             return 0
 
         if len(y_given_z0_y1) == 0:
             warn(
-                f"No samples with y_hat == {positive_target} for {sensitive_column} == 0, returning 0",
+                f"No samples with y_true == {positive_target} and y_hat == {positive_target} "
+                f"for {sensitive_column} == 0, returning 0",
                 RuntimeWarning,
             )
             return 0

--- a/tests/test_metrics/test_equal_opportunity.py
+++ b/tests/test_metrics/test_equal_opportunity.py
@@ -81,3 +81,4 @@ def test_warning_is_logged(sensitive_classification_dataset):
         # Trigger a warning.
         equal_opportunity_score("x2", positive_target=2)(mod_fair, X, y)
         assert issubclass(w[-1].category, RuntimeWarning)
+        assert "y_true == 2 and y_hat == 2" in str(w[-1].message)


### PR DESCRIPTION
Clarifies the warning emitted by `equal_opportunity_score` so it includes both the `y_true` and `y_hat` positive-target conditions that trigger the zero-return path.

This only updates the warning text and its regression coverage; it does not change the metric logic.
